### PR TITLE
Set up Swift package skeleton for peer discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "weave",
+    products: [
+        .executable(name: "weave", targets: ["weave"])
+    ],
+    dependencies: [
+        // TODO: Add libp2p dependency when available.
+    ],
+    targets: [
+        // Targets define modules or test suites.
+        .executableTarget(
+            name: "weave",
+            dependencies: []),
+        .testTarget(
+            name: "WeaveTests",
+            dependencies: ["weave"])
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Weave
+
+An experimental peer-to-peer dating application prototype. This repository
+contains a Swift Package that will eventually power the networking layer for an
+iOS client. The current prototype includes:
+
+- Basic `Peer` model storing network and location information.
+- `PeerManager` with rudimentary radius-based filtering using the Haversine formula.
+- Sample command-line entry point demonstrating peer filtering.
+- Unit test covering radius-based peer discovery logic.
+
+## Building
+
+```bash
+swift build
+```
+
+## Testing
+
+```bash
+swift test
+```
+
+## Next Steps
+
+- Integrate [libp2p](https://libp2p.io) for decentralised peer discovery and messaging.
+- Add geolocation fetching via CoreLocation on iOS.
+- Implement encrypted communication using CryptoKit.

--- a/Sources/Peer.swift
+++ b/Sources/Peer.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Represents a peer in the Weave network.
+/// Peers are identified by a unique ID and may advertise
+/// a network address and their geographic location.
+struct Peer: Identifiable, Codable, Equatable {
+    let id: UUID
+    var address: String?
+    var port: UInt16?
+    var latitude: Double
+    var longitude: Double
+
+    init(id: UUID = UUID(), address: String? = nil, port: UInt16? = nil, latitude: Double, longitude: Double) {
+        self.id = id
+        self.address = address
+        self.port = port
+        self.latitude = latitude
+        self.longitude = longitude
+    }
+}

--- a/Sources/PeerManager.swift
+++ b/Sources/PeerManager.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Manages known peers and provides basic discovery utilities.
+class PeerManager {
+    private var peers: [UUID: Peer] = [:]
+
+    /// Adds or updates a peer in the manager.
+    func add(_ peer: Peer) {
+        peers[peer.id] = peer
+    }
+
+    /// Removes a peer by id.
+    func remove(id: UUID) {
+        peers.removeValue(forKey: id)
+    }
+
+    /// Returns all known peers.
+    func allPeers() -> [Peer] {
+        Array(peers.values)
+    }
+
+    /// Returns peers within the given radius (in kilometers) of the provided location.
+    func peers(near latitude: Double, longitude: Double, radius: Double) -> [Peer] {
+        return peers.values.filter { peer in
+            distance(from: (latitude, longitude), to: (peer.latitude, peer.longitude)) <= radius
+        }
+    }
+
+    /// Haversine distance between two coordinates in kilometers.
+    private func distance(from: (Double, Double), to: (Double, Double)) -> Double {
+        let earthRadiusKm = 6371.0
+        let deltaLat = (to.0 - from.0) * Double.pi / 180
+        let deltaLon = (to.1 - from.1) * Double.pi / 180
+        let a = sin(deltaLat/2) * sin(deltaLat/2) +
+                cos(from.0 * Double.pi / 180) * cos(to.0 * Double.pi / 180) *
+                sin(deltaLon/2) * sin(deltaLon/2)
+        let c = 2 * atan2(sqrt(a), sqrt(1-a))
+        return earthRadiusKm * c
+    }
+}

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+// Demonstration of using the PeerManager. In the future this will
+// integrate with libp2p for real peer discovery and messaging.
+let manager = PeerManager()
+
+// Assume the current user is in San Francisco
+let selfLat = 37.7749
+let selfLon = -122.4194
+
+// Add a nearby peer and a distant peer
+manager.add(Peer(latitude: 37.7750, longitude: -122.4183)) // within ~0.1km
+manager.add(Peer(latitude: 40.7128, longitude: -74.0060))   // New York
+
+let nearbyPeers = manager.peers(near: selfLat, longitude: selfLon, radius: 5.0)
+print("Discovered \(nearbyPeers.count) nearby peer(s)")

--- a/Tests/WeaveTests/PeerManagerTests.swift
+++ b/Tests/WeaveTests/PeerManagerTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import weave
+
+final class PeerManagerTests: XCTestCase {
+    func testNearbyPeerFiltering() {
+        let manager = PeerManager()
+        let userLocation = Peer(latitude: 37.7749, longitude: -122.4194)
+        let nearby = Peer(latitude: 37.7750, longitude: -122.4195)
+        let farAway = Peer(latitude: 40.7128, longitude: -74.0060)
+
+        manager.add(nearby)
+        manager.add(farAway)
+
+        let results = manager.peers(near: userLocation.latitude, longitude: userLocation.longitude, radius: 10.0)
+        XCTAssertTrue(results.contains(nearby))
+        XCTAssertFalse(results.contains(farAway))
+    }
+
+    func testRemovingPeer() {
+        let manager = PeerManager()
+        let peer = Peer(latitude: 37.0, longitude: -122.0)
+        manager.add(peer)
+        XCTAssertEqual(manager.allPeers().count, 1)
+        manager.remove(id: peer.id)
+        XCTAssertEqual(manager.allPeers().count, 0)
+    }
+}


### PR DESCRIPTION
## Summary
- bootstrap Swift executable package for Weave
- add `Peer` model and `PeerManager` with radius-based filtering
- add removal support for stored peers
- demonstrate basic usage in `main.swift`
- include unit tests for peer filtering logic

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_688f7e3343d8832b90aea8eb3899a183