### PR TITLE
Set up Swift package skeleton for peer discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "weave",
+    products: [
+        .executable(name: "weave", targets: ["weave"])
+    ],
+    dependencies: [
+        // TODO: Add libp2p dependency when available.
+    ],
+    targets: [
+        // Targets define modules or test suites.
+        .executableTarget(
+            name: "weave",
+            dependencies: []),
+        .testTarget(
+            name: "WeaveTests",
+            dependencies: ["weave"])
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Weave
+
+An experimental peer-to-peer dating application prototype. This repository
+contains a Swift Package that will eventually power the networking layer for an
+iOS client. The current prototype includes:
+
+- Basic `Peer` model storing network and location information.
+- `PeerManager` with rudimentary radius-based filtering, optional attribute-based matching, and nearest-peer queries using the Haversine formula.
+- `PeerManager` supports peer removal and updates to location and attribute metadata.
+- Sample command-line entry point demonstrating peer filtering and updates.
+- Unit tests covering radius-based, proximity-sorted, attribute-filtered, and update logic.
+
+## Building
+
+```bash
+swift build
+```
+
+## Testing
+
+```bash
+swift test
+```
+
+## Next Steps
+
+- Integrate [libp2p](https://libp2p.io) for decentralised peer discovery and messaging.
+- Add geolocation fetching via CoreLocation on iOS.
+- Implement encrypted communication using CryptoKit.

--- a/Sources/Peer.swift
+++ b/Sources/Peer.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Represents a peer in the Weave network.
+/// Peers are identified by a unique ID and may advertise
+/// a network address and their geographic location.
+struct Peer: Identifiable, Codable, Equatable {
+    let id: UUID
+    var address: String?
+    var port: UInt16?
+    var latitude: Double
+    var longitude: Double
+    /// Arbitrary attributes describing the peer, used for filtering.
+    var attributes: [String: String]
+
+    init(id: UUID = UUID(),
+         address: String? = nil,
+         port: UInt16? = nil,
+         latitude: Double,
+         longitude: Double,
+         attributes: [String: String] = [:]) {
+        self.id = id
+        self.address = address
+        self.port = port
+        self.latitude = latitude
+        self.longitude = longitude
+        self.attributes = attributes
+    }
+}

--- a/Sources/PeerManager.swift
+++ b/Sources/PeerManager.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Manages known peers and provides basic discovery utilities.
+class PeerManager {
+    private var peerIndex: [UUID: Peer] = [:]
+
+    /// Adds or updates a peer in the manager.
+    func add(_ peer: Peer) {
+        peerIndex[peer.id] = peer
+    }
+
+    /// Removes a peer by id.
+    func remove(id: UUID) {
+        peerIndex.removeValue(forKey: id)
+    }
+
+    /// Returns the peer with the given id, if present.
+    func peer(id: UUID) -> Peer? {
+        peerIndex[id]
+    }
+
+    /// Updates a peer's geographic location if it exists in the manager.
+    func updateLocation(id: UUID, latitude: Double, longitude: Double) {
+        guard var peer = peerIndex[id] else { return }
+        peer.latitude = latitude
+        peer.longitude = longitude
+        peerIndex[id] = peer
+    }
+
+    /// Replaces a peer's attributes dictionary if it exists in the manager.
+    func updateAttributes(id: UUID, attributes: [String: String]) {
+        guard var peer = peerIndex[id] else { return }
+        peer.attributes = attributes
+        peerIndex[id] = peer
+    }
+
+    /// Returns all known peers.
+    func allPeers() -> [Peer] {
+        Array(peerIndex.values)
+    }
+
+    /// Returns peers within the given radius (in kilometers) of the provided location.
+    /// Optional attribute filters can further restrict the results.
+    func peers(near latitude: Double,
+               longitude: Double,
+               radius: Double,
+               matching filters: [String: String] = [:]) -> [Peer] {
+        return peerIndex.values.filter { peer in
+            distance(from: (latitude, longitude), to: (peer.latitude, peer.longitude)) <= radius &&
+            filters.allSatisfy { key, value in peer.attributes[key] == value }
+        }
+    }
+
+    /// Returns up to `limit` peers sorted by proximity to the provided location.
+    func nearestPeers(to latitude: Double, longitude: Double, limit: Int) -> [Peer] {
+        let sorted = peerIndex.values.sorted {
+            distance(from: (latitude, longitude), to: ($0.latitude, $0.longitude)) <
+            distance(from: (latitude, longitude), to: ($1.latitude, $1.longitude))
+        }
+        return Array(sorted.prefix(limit))
+    }
+
+    /// Haversine distance between two coordinates in kilometers.
+    private func distance(from: (Double, Double), to: (Double, Double)) -> Double {
+        let earthRadiusKm = 6371.0
+        let deltaLat = (to.0 - from.0) * Double.pi / 180
+        let deltaLon = (to.1 - from.1) * Double.pi / 180
+        let a = sin(deltaLat/2) * sin(deltaLat/2) +
+                cos(from.0 * Double.pi / 180) * cos(to.0 * Double.pi / 180) *
+                sin(deltaLon/2) * sin(deltaLon/2)
+        let c = 2 * atan2(sqrt(a), sqrt(1-a))
+        return earthRadiusKm * c
+    }
+}

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+// Demonstration of using the PeerManager. In the future this will
+// integrate with libp2p for real peer discovery and messaging.
+let manager = PeerManager()
+
+// Assume the current user is in San Francisco
+let selfLat = 37.7749
+let selfLon = -122.4194
+
+// Add a peer in San Francisco
+let movingPeer = Peer(latitude: 37.7750, longitude: -122.4183, attributes: ["hobby": "hiking"])
+manager.add(movingPeer)
+
+var nearbyPeers = manager.peers(near: selfLat, longitude: selfLon, radius: 5.0)
+print("Discovered \(nearbyPeers.count) nearby peer(s)")
+
+// Update the peer's location to New York
+manager.updateLocation(id: movingPeer.id, latitude: 40.7128, longitude: -74.0060)
+nearbyPeers = manager.peers(near: selfLat, longitude: selfLon, radius: 5.0)
+print("Nearby peers after move: \(nearbyPeers.count)")
+
+let hikers = manager.peers(near: selfLat, longitude: selfLon, radius: 5000.0, matching: ["hobby": "hiking"])
+print("Hikers within 5000km: \(hikers.count)")

--- a/Tests/WeaveTests/PeerManagerTests.swift
+++ b/Tests/WeaveTests/PeerManagerTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import weave
+
+final class PeerManagerTests: XCTestCase {
+    func testFiltersNearbyPeers() {
+        let manager = PeerManager()
+        let userLocation = Peer(latitude: 37.7749, longitude: -122.4194)
+        let nearby = Peer(latitude: 37.7750, longitude: -122.4195)
+        let farAway = Peer(latitude: 40.7128, longitude: -74.0060)
+
+        manager.add(nearby)
+        manager.add(farAway)
+
+        let filteredPeers = manager.peers(near: userLocation.latitude, longitude: userLocation.longitude, radius: 10.0)
+        XCTAssertTrue(filteredPeers.contains(nearby))
+        XCTAssertFalse(filteredPeers.contains(farAway))
+    }
+
+    func testRemovingPeerUpdatesIndex() {
+        let manager = PeerManager()
+        let peer = Peer(latitude: 37.0, longitude: -122.0)
+        manager.add(peer)
+        XCTAssertEqual(manager.allPeers().count, 1)
+        manager.remove(id: peer.id)
+        XCTAssertEqual(manager.allPeers().count, 0)
+    }
+
+    func testNearestPeersReturnsSortedResults() {
+        let manager = PeerManager()
+        let origin = Peer(latitude: 0.0, longitude: 0.0)
+        let nearer = Peer(latitude: 0.0, longitude: 0.05) // ~5.5km east
+        let near = Peer(latitude: 0.0, longitude: 0.1)   // ~11km east
+
+        manager.add(near)
+        manager.add(nearer)
+
+        let results = manager.nearestPeers(to: origin.latitude, longitude: origin.longitude, limit: 2)
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results[0], nearer)
+        XCTAssertEqual(results[1], near)
+    }
+
+    func testAttributeFilteringReturnsMatches() {
+        let manager = PeerManager()
+        let hiker = Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "hiking"])
+        let gamer = Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "gaming"])
+
+        manager.add(hiker)
+        manager.add(gamer)
+
+        let results = manager.peers(near: 0.0, longitude: 0.0, radius: 1.0, matching: ["hobby": "hiking"])
+        XCTAssertEqual(results, [hiker])
+    }
+
+    func testUpdatingPeerLocation() {
+        let manager = PeerManager()
+        let peer = Peer(latitude: 0.0, longitude: 0.0)
+        manager.add(peer)
+        manager.updateLocation(id: peer.id, latitude: 1.0, longitude: 1.0)
+        let updated = manager.peer(id: peer.id)
+        XCTAssertEqual(updated?.latitude, 1.0)
+        XCTAssertEqual(updated?.longitude, 1.0)
+    }
+
+    func testUpdatingPeerAttributes() {
+        let manager = PeerManager()
+        let peer = Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "gaming"])
+        manager.add(peer)
+        manager.updateAttributes(id: peer.id, attributes: ["hobby": "hiking"])
+        let updated = manager.peer(id: peer.id)
+        XCTAssertEqual(updated?.attributes["hobby"], "hiking")
+    }
+}


### PR DESCRIPTION
## Summary
- extend `Peer` with arbitrary attribute metadata
- allow `PeerManager` radius and nearest lookups with optional attribute filters
- add APIs to fetch and update peer location and attributes, with updated example and docs

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_688f7e3343d8832b90aea8eb3899a183