### PR TITLE
Add placeholder P2P node and document tech stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "weave",
+    products: [
+        .executable(name: "weave", targets: ["weave"])
+    ],
+    dependencies: [
+        // TODO: Add libp2p dependency when available.
+    ],
+    targets: [
+        // Targets define modules or test suites.
+        .executableTarget(
+            name: "weave",
+            dependencies: []),
+        .testTarget(
+            name: "WeaveTests",
+            dependencies: ["weave"])
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# Weave
+
+An experimental peer-to-peer dating application prototype. This repository
+contains a Swift Package that will eventually power the networking layer for an
+iOS client. The current prototype includes:
+
+- Basic `Peer` model storing a display name, network details, location and last-seen timestamp information.
+- `PeerManager` with rudimentary radius-based filtering, geohash prefix queries (with optional attribute filters), optional attribute-based matching, and nearest-peer queries (with optional attribute filters) using the Haversine formula.
+- `PeerManager` supports peer removal, updates to display name, network address, location and attribute metadata (including individual attribute changes), pruning of stale peers by last-seen time, and blocking/unblocking of peers.
+- `PeerManager` can rank nearby peers by shared attribute matches.
+- `PeerManager` provides a `connect(to:)` helper that refreshes last-seen timestamps while respecting block lists.
+- `PeerManager` can list the most recently seen peers for recency-based discovery.
+- `PeerManager` supports liking and unliking peers and retrieving liked peers.
+- `PeerManager` can determine mutual matches by returning liked peers whose attributes
+  indicate they like the current user.
+- `PeerStore` persists known peers, blocked IDs, and liked peers to disk and restores them on launch.
+- Sample command-line entry point demonstrating peer filtering, geohash prefix queries (with attribute filters), nearest-peer querying, updates (including display name and attribute tweaks), blocking, liking and pruning.
+- Unit tests covering radius-based, proximity-sorted, attribute-filtered, matching, update, blocking and pruning logic.
+
+## Technology Stack
+
+| Area | Technologies | Purpose |
+|------|--------------|---------|
+| Programming Language & UI | Swift + SwiftUI | Native iOS development with a modern declarative interface. |
+| P2P Networking | libp2p (Kademlia DHT) | Serverless peer discovery and secure transport across the internet. |
+| NAT Traversal | UDP hole punching, UPnP / NAT-PMP | Enables peers behind home routers to reach each other directly. |
+| Geolocation | CoreLocation | Retrieves user coordinates for radius-based filtering. |
+| Local Discovery | mDNS / Bonjour (optional) | Finds nearby peers on the same network when offline. |
+| Persistence | CoreData or SQLite | Stores profiles, preferences and chat history on-device. |
+| Encryption | CryptoKit or libsodium | Provides end-to-end encryption for sensitive data and messages. |
+| Notifications | APNs (optional) | Alerts users about messages or connection requests when backgrounded. |
+
+## Building
+
+```bash
+swift build
+```
+
+## Testing
+
+```bash
+swift test
+```
+
+## Next Steps
+
+- Integrate [libp2p](https://libp2p.io) for decentralised peer discovery and messaging.
+- Add geolocation fetching via CoreLocation on iOS.
+- Implement encrypted communication using CryptoKit.
+- Use geohash bucketing to index peers in a distributed hash table for efficient location-based lookups.

--- a/Sources/GeoHash.swift
+++ b/Sources/GeoHash.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Utility for encoding geographic coordinates into a geohash string.
+/// Geohashes compactly represent latitude/longitude pairs and can be used
+/// for coarse spatial grouping, e.g. when indexing peers in a distributed
+/// hash table.
+struct GeoHash {
+    private static let base32: [Character] = Array("0123456789bcdefghjkmnpqrstuvwxyz")
+
+    /// Encodes the given latitude and longitude into a geohash string with the
+    /// specified precision (number of characters).
+    static func encode(latitude: Double, longitude: Double, precision: Int = 8) -> String {
+        var latInterval = (-90.0, 90.0)
+        var lonInterval = (-180.0, 180.0)
+        var isEven = true
+        var bit = 0
+        var ch = 0
+        var hash: [Character] = []
+
+        while hash.count < precision {
+            if isEven {
+                let mid = (lonInterval.0 + lonInterval.1) / 2
+                if longitude > mid {
+                    ch |= 1 << (4 - bit)
+                    lonInterval.0 = mid
+                } else {
+                    lonInterval.1 = mid
+                }
+            } else {
+                let mid = (latInterval.0 + latInterval.1) / 2
+                if latitude > mid {
+                    ch |= 1 << (4 - bit)
+                    latInterval.0 = mid
+                } else {
+                    latInterval.1 = mid
+                }
+            }
+
+            isEven.toggle()
+            if bit < 4 {
+                bit += 1
+            } else {
+                hash.append(base32[ch])
+                bit = 0
+                ch = 0
+            }
+        }
+
+        return String(hash)
+    }
+}
+

--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// A placeholder networking node that will integrate libp2p in the future.
+/// For now it simply tracks bootstrap peers and whether the node is running.
+final class P2PNode {
+    /// Addresses of peers used to join the wider network.
+    private let bootstrapPeers: [String]
+    /// Indicates whether the node is actively running.
+    private(set) var isRunning: Bool = false
+
+    init(bootstrapPeers: [String] = []) {
+        self.bootstrapPeers = bootstrapPeers
+    }
+
+    /// Starts the networking stack. In a real implementation this would
+    /// initialise libp2p, perform NAT traversal and begin listening for peers.
+    func start() {
+        isRunning = true
+    }
+
+    /// Stops the networking stack and cleans up resources.
+    func stop() {
+        isRunning = false
+    }
+}
+

--- a/Sources/Peer.swift
+++ b/Sources/Peer.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Represents a peer in the Weave network.
+/// Peers are identified by a unique ID and may advertise
+/// a network address and their geographic location.
+struct Peer: Identifiable, Codable, Equatable {
+    let id: UUID
+    /// Optional human-friendly display name.
+    var name: String?
+    var address: String?
+    var port: UInt16?
+    var latitude: Double
+    var longitude: Double
+    /// Arbitrary attributes describing the peer, used for filtering.
+    var attributes: [String: String]
+    /// When this peer was last seen or updated.
+    var lastSeen: Date
+
+    /// Geohash representation of the peer's location for spatial indexing.
+    var geohash: String {
+        GeoHash.encode(latitude: latitude, longitude: longitude)
+    }
+
+    init(id: UUID = UUID(),
+         name: String? = nil,
+         address: String? = nil,
+         port: UInt16? = nil,
+         latitude: Double,
+         longitude: Double,
+         attributes: [String: String] = [:],
+         lastSeen: Date = Date()) {
+        self.id = id
+        self.name = name
+        self.address = address
+        self.port = port
+        self.latitude = latitude
+        self.longitude = longitude
+        self.attributes = attributes
+        self.lastSeen = lastSeen
+    }
+
+    static func == (lhs: Peer, rhs: Peer) -> Bool {
+        lhs.id == rhs.id &&
+        lhs.name == rhs.name &&
+        lhs.address == rhs.address &&
+        lhs.port == rhs.port &&
+        lhs.latitude == rhs.latitude &&
+        lhs.longitude == rhs.longitude &&
+        lhs.attributes == rhs.attributes
+    }
+}

--- a/Sources/PeerManager.swift
+++ b/Sources/PeerManager.swift
@@ -1,0 +1,243 @@
+import Foundation
+
+/// Manages known peers and provides basic discovery utilities.
+class PeerManager {
+    private var peerIndex: [UUID: Peer] = [:]
+    private var blocked: Set<UUID> = []
+    private var liked: Set<UUID> = []
+
+    /// Marks a peer as blocked, excluding it from discovery APIs.
+    func block(id: UUID) {
+        blocked.insert(id)
+        liked.remove(id)
+    }
+
+    /// Removes a peer from the blocked list.
+    func unblock(id: UUID) {
+        blocked.remove(id)
+    }
+
+    /// Marks a peer as liked if it exists and is not blocked.
+    func like(id: UUID) {
+        guard peerIndex[id] != nil, !blocked.contains(id) else { return }
+        liked.insert(id)
+    }
+
+    /// Removes a peer from the liked list.
+    func unlike(id: UUID) {
+        liked.remove(id)
+    }
+
+    /// Returns all liked peers that are not currently blocked.
+    func likedPeers() -> [Peer] {
+        liked.compactMap { peerIndex[$0] }.filter { !blocked.contains($0.id) }
+    }
+
+    /// Returns liked peers that have indicated they like the given user.
+    /// A peer is considered a mutual match if its attributes contain the
+    /// provided `userID` under the key "likes".
+    func mutualLikes(for userID: UUID) -> [Peer] {
+        liked.compactMap { peerIndex[$0] }
+            .filter { $0.attributes["likes"] == userID.uuidString && !blocked.contains($0.id) }
+    }
+
+    /// Adds or updates a peer in the manager.
+    func add(_ peer: Peer) {
+        peerIndex[peer.id] = peer
+    }
+
+    /// Removes a peer by id.
+    func remove(id: UUID) {
+        peerIndex.removeValue(forKey: id)
+        blocked.remove(id)
+        liked.remove(id)
+    }
+
+    /// Returns the peer with the given id, if present.
+    func peer(id: UUID) -> Peer? {
+        peerIndex[id]
+    }
+
+    /// Updates a peer's geographic location if it exists in the manager.
+    func updateLocation(id: UUID, latitude: Double, longitude: Double) {
+        guard var peer = peerIndex[id] else { return }
+        peer.latitude = latitude
+        peer.longitude = longitude
+        peer.lastSeen = Date()
+        peerIndex[id] = peer
+    }
+
+    /// Replaces a peer's attributes dictionary if it exists in the manager.
+    func updateAttributes(id: UUID, attributes: [String: String]) {
+        guard var peer = peerIndex[id] else { return }
+        peer.attributes = attributes
+        peer.lastSeen = Date()
+        peerIndex[id] = peer
+    }
+
+    /// Sets or replaces a single attribute on the peer if present.
+    func updateAttribute(id: UUID, key: String, value: String) {
+        guard var peer = peerIndex[id] else { return }
+        peer.attributes[key] = value
+        peer.lastSeen = Date()
+        peerIndex[id] = peer
+    }
+
+    /// Removes a single attribute from the peer if present.
+    func removeAttribute(id: UUID, key: String) {
+        guard var peer = peerIndex[id] else { return }
+        peer.attributes.removeValue(forKey: key)
+        peer.lastSeen = Date()
+        peerIndex[id] = peer
+    }
+
+    /// Updates a peer's network address and port if it exists in the manager.
+    func updateAddress(id: UUID, address: String?, port: UInt16?) {
+        guard var peer = peerIndex[id] else { return }
+        peer.address = address
+        peer.port = port
+        peer.lastSeen = Date()
+        peerIndex[id] = peer
+    }
+
+    /// Updates a peer's display name if it exists in the manager.
+    func updateName(id: UUID, name: String?) {
+        guard var peer = peerIndex[id] else { return }
+        peer.name = name
+        peer.lastSeen = Date()
+        peerIndex[id] = peer
+    }
+
+    /// Updates the last-seen timestamp for the given peer to the provided date (defaults to now).
+    func updateLastSeen(id: UUID, at date: Date = Date()) {
+        guard var peer = peerIndex[id] else { return }
+        peer.lastSeen = date
+        peerIndex[id] = peer
+    }
+
+    /// Simulates connecting to the peer with the given id. Returns `true` if the
+    /// peer exists and is not blocked. A successful connection refreshes the
+    /// peer's last-seen timestamp.
+    func connect(to id: UUID) -> Bool {
+        guard var peer = peerIndex[id], !blocked.contains(id) else { return false }
+        peer.lastSeen = Date()
+        peerIndex[id] = peer
+        return true
+    }
+
+    /// Returns all known peers.
+    func allPeers() -> [Peer] {
+        peerIndex.values.filter { !blocked.contains($0.id) }
+    }
+
+    /// Returns peers within the given radius (in kilometers) of the provided location.
+    /// Optional attribute filters can further restrict the results.
+    func peers(near latitude: Double,
+               longitude: Double,
+               radius: Double,
+               matching filters: [String: String] = [:]) -> [Peer] {
+        return peerIndex.values.filter { peer in
+            !blocked.contains(peer.id) &&
+            distance(from: (latitude, longitude), to: (peer.latitude, peer.longitude)) <= radius &&
+            filters.allSatisfy { key, value in peer.attributes[key] == value }
+        }
+    }
+
+    /// Returns peers whose geohash begins with the specified prefix. Useful for
+    /// coarse location-based grouping using geohash bucketing. Optional
+    /// attribute filters can further restrict the results.
+    func peers(inGeohash prefix: String, matching filters: [String: String] = [:]) -> [Peer] {
+        peerIndex.values.filter { peer in
+            !blocked.contains(peer.id) &&
+            peer.geohash.hasPrefix(prefix) &&
+            filters.allSatisfy { key, value in peer.attributes[key] == value }
+        }
+    }
+
+    /// Returns up to `limit` peers sorted by proximity to the provided location.
+    /// Optional attribute filters can restrict the results to peers matching all
+    /// specified key/value pairs.
+    func nearestPeers(to latitude: Double,
+                      longitude: Double,
+                      limit: Int,
+                      matching filters: [String: String] = [:]) -> [Peer] {
+        let sorted = peerIndex.values
+            .filter { peer in
+                !blocked.contains(peer.id) &&
+                filters.allSatisfy { key, value in peer.attributes[key] == value }
+            }
+            .sorted {
+                distance(from: (latitude, longitude), to: ($0.latitude, $0.longitude)) <
+                distance(from: (latitude, longitude), to: ($1.latitude, $1.longitude))
+            }
+        return Array(sorted.prefix(limit))
+    }
+
+    /// Returns up to `limit` most recently seen peers, excluding any that are blocked.
+    func recentPeers(limit: Int) -> [Peer] {
+        let sorted = peerIndex.values
+            .filter { !blocked.contains($0.id) }
+            .sorted { $0.lastSeen > $1.lastSeen }
+        return Array(sorted.prefix(limit))
+    }
+
+    /// Returns up to `limit` peers within `radius` kilometers of the given peer,
+    /// ranked first by number of matching attribute key/value pairs and then by
+    /// proximity (closest first).
+    func matchPeers(for peer: Peer, radius: Double, limit: Int) -> [Peer] {
+        let results: [(peer: Peer, score: Int, distance: Double)] = peerIndex.values.compactMap { candidate in
+            guard candidate.id != peer.id, !blocked.contains(candidate.id) else { return nil }
+            let dist = distance(from: (peer.latitude, peer.longitude), to: (candidate.latitude, candidate.longitude))
+            guard dist <= radius else { return nil }
+
+            let score = peer.attributes.reduce(0) { acc, pair in
+                acc + (candidate.attributes[pair.key] == pair.value ? 1 : 0)
+            }
+            return (candidate, score, dist)
+        }
+
+        return results
+            .sorted { lhs, rhs in
+                if lhs.score == rhs.score {
+                    return lhs.distance < rhs.distance
+                } else {
+                    return lhs.score > rhs.score
+                }
+            }
+            .prefix(limit)
+            .map { $0.peer }
+    }
+
+    /// Removes peers that were last seen before the provided cutoff date.
+    func pruneStale(before cutoff: Date) {
+        peerIndex = peerIndex.filter { $0.value.lastSeen >= cutoff }
+        blocked = blocked.filter { peerIndex[$0] != nil }
+    }
+
+    /// Haversine distance between two coordinates in kilometers.
+    private func distance(from: (Double, Double), to: (Double, Double)) -> Double {
+        let earthRadiusKm = 6371.0
+        let deltaLat = (to.0 - from.0) * Double.pi / 180
+        let deltaLon = (to.1 - from.1) * Double.pi / 180
+        let a = sin(deltaLat/2) * sin(deltaLat/2) +
+                cos(from.0 * Double.pi / 180) * cos(to.0 * Double.pi / 180) *
+                sin(deltaLon/2) * sin(deltaLon/2)
+        let c = 2 * atan2(sqrt(a), sqrt(1-a))
+        return earthRadiusKm * c
+    }
+
+    /// Persists all known peers along with blocked and liked IDs using the provided store.
+    func save(to store: PeerStore) throws {
+        try store.save(peers: Array(peerIndex.values),
+                      blocked: Array(blocked),
+                      liked: Array(liked))
+    }
+
+    /// Loads peers (and blocked/liked IDs) from the provided store, replacing any existing data.
+    func load(from store: PeerStore) throws {
+        let snapshot = try store.load()
+        peerIndex = Dictionary(uniqueKeysWithValues: snapshot.peers.map { ($0.id, $0) })
+        blocked = Set(snapshot.blocked.filter { peerIndex[$0] != nil })
+        liked = Set(snapshot.liked.filter { peerIndex[$0] != nil && !blocked.contains($0) })
+    }
+}

--- a/Sources/PeerStore.swift
+++ b/Sources/PeerStore.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Persists and restores peers (and the block/liked lists) to and from disk using JSON
+/// encoding.
+struct PeerStore {
+    let url: URL
+
+    private struct Snapshot: Codable {
+        var peers: [Peer]
+        var blocked: [UUID]
+        var liked: [UUID]
+
+        init(peers: [Peer], blocked: [UUID], liked: [UUID] = []) {
+            self.peers = peers
+            self.blocked = blocked
+            self.liked = liked
+        }
+    }
+
+    /// Saves the provided peers and blocked/liked IDs to disk, overwriting any
+    /// existing file.
+    func save(peers: [Peer], blocked: [UUID], liked: [UUID] = []) throws {
+        let snapshot = Snapshot(peers: peers, blocked: blocked, liked: liked)
+        let data = try JSONEncoder().encode(snapshot)
+        try data.write(to: url, options: .atomic)
+    }
+
+    /// Loads peers and blocked/liked IDs from disk. Returns empty collections if the
+    /// file does not exist. For backward compatibility with older save formats,
+    /// a plain array of peers can still be decoded.
+    func load() throws -> (peers: [Peer], blocked: [UUID], liked: [UUID]) {
+        guard FileManager.default.fileExists(atPath: url.path) else { return ([], [], []) }
+        let data = try Data(contentsOf: url)
+        if let snapshot = try? JSONDecoder().decode(Snapshot.self, from: data) {
+            return (snapshot.peers, snapshot.blocked, snapshot.liked)
+        }
+
+        let peers = try JSONDecoder().decode([Peer].self, from: data)
+        return (peers, [], [])
+    }
+}

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+// Demonstration of using the PeerManager alongside a placeholder
+// networking node that will eventually speak libp2p.
+let node = P2PNode(bootstrapPeers: ["bootstrap.weave.example:4001"])
+node.start()
+defer { node.stop() }
+let manager = PeerManager()
+
+// Assume the current user is in San Francisco
+let selfLat = 37.7749
+let selfLon = -122.4194
+let me = Peer(name: "Me", latitude: selfLat, longitude: selfLon, attributes: ["hobby": "hiking"])
+
+// Add a peer in San Francisco who likes the current user
+let movingPeer = Peer(name: "Alice", latitude: 37.7750, longitude: -122.4183, attributes: ["hobby": "hiking", "likes": me.id.uuidString])
+manager.add(movingPeer)
+
+// Add another peer in San Francisco with a different hobby
+let otherSF = Peer(name: "Eve", latitude: 37.7751, longitude: -122.4185, attributes: ["hobby": "music"])
+manager.add(otherSF)
+
+// Add a peer in Los Angeles with the same hobby as the current user
+let laPeer = Peer(name: "Bob", latitude: 34.0522, longitude: -118.2437, attributes: ["hobby": "hiking"])
+manager.add(laPeer)
+
+// Query peers sharing the same geohash prefix as the moving peer (coarse area match)
+let prefix = String(movingPeer.geohash.prefix(5))
+let geohashPeers = manager.peers(inGeohash: prefix)
+print("Peers in geohash prefix \(prefix): \(geohashPeers.count)")
+let hikingInPrefix = manager.peers(inGeohash: prefix, matching: ["hobby": "hiking"])
+print("Hiking peers in geohash prefix \(prefix): \(hikingInPrefix.count)")
+
+var nearbyPeers = manager.peers(near: selfLat, longitude: selfLon, radius: 5000.0)
+print("Peers within 5000km: \(nearbyPeers.count)")
+
+// Connect to the moving peer and refresh its last-seen timestamp
+if manager.connect(to: movingPeer.id) {
+    print("Connected to moving peer")
+}
+
+// Like and then unlike the moving peer
+manager.like(id: movingPeer.id)
+print("Liked peers: \(manager.likedPeers().count)")
+manager.unlike(id: movingPeer.id)
+print("Liked peers after unlike: \(manager.likedPeers().count)")
+// Like again to demonstrate mutual match detection
+manager.like(id: movingPeer.id)
+let mutual = manager.mutualLikes(for: me.id)
+print("Mutual matches: \(mutual.count)")
+
+// Block the Los Angeles peer
+manager.block(id: laPeer.id)
+nearbyPeers = manager.peers(near: selfLat, longitude: selfLon, radius: 5000.0)
+print("Peers after blocking LA user: \(nearbyPeers.count)")
+
+// Update the peer's location to New York
+manager.updateLocation(id: movingPeer.id, latitude: 40.7128, longitude: -74.0060)
+nearbyPeers = manager.peers(near: selfLat, longitude: selfLon, radius: 5.0)
+print("Nearby peers after move: \(nearbyPeers.count)")
+
+// Update the peer's network address
+manager.updateAddress(id: movingPeer.id, address: "203.0.113.1", port: 8080)
+if let updated = manager.peer(id: movingPeer.id) {
+    print("Peer network address: \(updated.address ?? "n/a"):\(updated.port ?? 0)")
+}
+
+// Change the peer's display name
+manager.updateName(id: movingPeer.id, name: "Traveler")
+print("Peer name after update: \(manager.peer(id: movingPeer.id)?.name ?? "none")")
+
+// Update a single attribute and then remove it
+manager.updateAttribute(id: movingPeer.id, key: "hobby", value: "climbing")
+print("Updated hobby: \(manager.peer(id: movingPeer.id)?.attributes["hobby"] ?? "none")")
+manager.removeAttribute(id: movingPeer.id, key: "hobby")
+print("Hobby after removal: \(manager.peer(id: movingPeer.id)?.attributes["hobby"] ?? "none")")
+
+let hikers = manager.peers(near: selfLat, longitude: selfLon, radius: 5000.0, matching: ["hobby": "hiking"])
+print("Hikers within 5000km: \(hikers.count)")
+
+let matches = manager.matchPeers(for: me, radius: 5000.0, limit: 5)
+print("Top matches by hobby within 5000km: \(matches.count)")
+
+let nearestHikers = manager.nearestPeers(to: selfLat,
+                                         longitude: selfLon,
+                                         limit: 3,
+                                         matching: ["hobby": "hiking"])
+print("Nearest hikers: \(nearestHikers.count)")
+
+// Persist peers to disk and load them back
+let storeURL = URL(fileURLWithPath: "/tmp/peers.json")
+let store = PeerStore(url: storeURL)
+try? manager.save(to: store)
+let restored = PeerManager()
+try? restored.load(from: store)
+print("Restored \(restored.allPeers().count) peer(s) from disk (blocked peers excluded)")
+restored.unblock(id: laPeer.id)
+print("After unblocking LA user post-restore: \(restored.allPeers().count) peer(s)")
+
+// Demonstrate pruning stale peers
+let stalePeer = Peer(latitude: 35.0, longitude: -120.0, lastSeen: Date(timeIntervalSinceNow: -7200))
+manager.add(stalePeer)
+print("Total peers before pruning: \(manager.allPeers().count)")
+manager.pruneStale(before: Date(timeIntervalSinceNow: -3600))
+print("Peers after pruning stale entries: \(manager.allPeers().count)")
+
+// Fetch the most recently seen peers
+let recent = manager.recentPeers(limit: 2)
+print("Most recently seen peers: \(recent.count)")

--- a/Tests/WeaveTests/P2PNodeTests.swift
+++ b/Tests/WeaveTests/P2PNodeTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+@testable import weave
+
+final class P2PNodeTests: XCTestCase {
+    func testStartAndStopToggleRunningState() {
+        let node = P2PNode(bootstrapPeers: ["1.2.3.4:4001"])
+        XCTAssertFalse(node.isRunning)
+        node.start()
+        XCTAssertTrue(node.isRunning)
+        node.stop()
+        XCTAssertFalse(node.isRunning)
+    }
+}

--- a/Tests/WeaveTests/PeerManagerTests.swift
+++ b/Tests/WeaveTests/PeerManagerTests.swift
@@ -1,0 +1,334 @@
+import XCTest
+import Foundation
+@testable import weave
+
+final class PeerManagerTests: XCTestCase {
+    func testFiltersNearbyPeers() {
+        let manager = PeerManager()
+        let userLocation = Peer(latitude: 37.7749, longitude: -122.4194)
+        let nearby = Peer(latitude: 37.7750, longitude: -122.4195)
+        let farAway = Peer(latitude: 40.7128, longitude: -74.0060)
+
+        manager.add(nearby)
+        manager.add(farAway)
+
+        let filteredPeers = manager.peers(near: userLocation.latitude, longitude: userLocation.longitude, radius: 10.0)
+        XCTAssertTrue(filteredPeers.contains(nearby))
+        XCTAssertFalse(filteredPeers.contains(farAway))
+    }
+
+    func testRemovingPeerUpdatesIndex() {
+        let manager = PeerManager()
+        let peer = Peer(latitude: 37.0, longitude: -122.0)
+        manager.add(peer)
+        XCTAssertEqual(manager.allPeers().count, 1)
+        manager.remove(id: peer.id)
+        XCTAssertEqual(manager.allPeers().count, 0)
+    }
+
+    func testNearestPeersReturnsSortedResults() {
+        let manager = PeerManager()
+        let origin = Peer(latitude: 0.0, longitude: 0.0)
+        let nearer = Peer(latitude: 0.0, longitude: 0.05) // ~5.5km east
+        let near = Peer(latitude: 0.0, longitude: 0.1)   // ~11km east
+
+        manager.add(near)
+        manager.add(nearer)
+
+        let results = manager.nearestPeers(to: origin.latitude, longitude: origin.longitude, limit: 2)
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results[0], nearer)
+        XCTAssertEqual(results[1], near)
+    }
+
+    func testNearestPeersRespectsAttributeFilters() {
+        let manager = PeerManager()
+        let origin = Peer(latitude: 0.0, longitude: 0.0)
+        let hikingPeer = Peer(latitude: 0.0, longitude: 0.05, attributes: ["hobby": "hiking"])
+        let gamingPeer = Peer(latitude: 0.0, longitude: 0.02, attributes: ["hobby": "gaming"])
+
+        manager.add(hikingPeer)
+        manager.add(gamingPeer)
+
+        let results = manager.nearestPeers(to: origin.latitude,
+                                           longitude: origin.longitude,
+                                           limit: 5,
+                                           matching: ["hobby": "hiking"])
+        XCTAssertEqual(results, [hikingPeer])
+    }
+
+    func testAttributeFilteringReturnsMatches() {
+        let manager = PeerManager()
+        let hiker = Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "hiking"])
+        let gamer = Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "gaming"])
+
+        manager.add(hiker)
+        manager.add(gamer)
+
+        let results = manager.peers(near: 0.0, longitude: 0.0, radius: 1.0, matching: ["hobby": "hiking"])
+        XCTAssertEqual(results, [hiker])
+    }
+
+    func testUpdatingPeerLocation() {
+        let manager = PeerManager()
+        let peer = Peer(latitude: 0.0, longitude: 0.0)
+        manager.add(peer)
+        manager.updateLocation(id: peer.id, latitude: 1.0, longitude: 1.0)
+        let updated = manager.peer(id: peer.id)
+        XCTAssertEqual(updated?.latitude, 1.0)
+        XCTAssertEqual(updated?.longitude, 1.0)
+    }
+
+    func testUpdatingPeerAttributes() {
+        let manager = PeerManager()
+        let peer = Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "gaming"])
+        manager.add(peer)
+        manager.updateAttributes(id: peer.id, attributes: ["hobby": "hiking"])
+        let updated = manager.peer(id: peer.id)
+        XCTAssertEqual(updated?.attributes["hobby"], "hiking")
+    }
+
+    func testUpdatingSingleAttribute() {
+        let manager = PeerManager()
+        let peer = Peer(latitude: 0.0, longitude: 0.0)
+        manager.add(peer)
+        manager.updateAttribute(id: peer.id, key: "hobby", value: "chess")
+        let updated = manager.peer(id: peer.id)
+        XCTAssertEqual(updated?.attributes["hobby"], "chess")
+    }
+
+    func testRemovingAttribute() {
+        let manager = PeerManager()
+        let peer = Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "chess"])
+        manager.add(peer)
+        manager.removeAttribute(id: peer.id, key: "hobby")
+        let updated = manager.peer(id: peer.id)
+        XCTAssertNil(updated?.attributes["hobby"])
+    }
+
+    func testUpdatingPeerAddress() {
+        let manager = PeerManager()
+        let peer = Peer(address: "1.2.3.4", port: 1000, latitude: 0.0, longitude: 0.0)
+        manager.add(peer)
+        manager.updateAddress(id: peer.id, address: "5.6.7.8", port: 2000)
+        let updated = manager.peer(id: peer.id)
+        XCTAssertEqual(updated?.address, "5.6.7.8")
+        XCTAssertEqual(updated?.port, 2000)
+    }
+
+    func testUpdatingPeerName() {
+        let manager = PeerManager()
+        let peer = Peer(name: "Old", latitude: 0.0, longitude: 0.0)
+        manager.add(peer)
+        manager.updateName(id: peer.id, name: "New")
+        let updated = manager.peer(id: peer.id)
+        XCTAssertEqual(updated?.name, "New")
+        XCTAssertNotEqual(updated?.lastSeen, peer.lastSeen)
+    }
+
+    func testMatchPeersRanksByAttributeScoreThenDistance() {
+        let manager = PeerManager()
+        let origin = Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "hiking"])
+        let nearMatch = Peer(latitude: 0.0, longitude: 0.05, attributes: ["hobby": "hiking"])
+        let farMatch = Peer(latitude: 0.0, longitude: 1.0, attributes: ["hobby": "hiking"])
+        let nonMatch = Peer(latitude: 0.0, longitude: 0.05, attributes: ["hobby": "gaming"])
+
+        manager.add(nearMatch)
+        manager.add(farMatch)
+        manager.add(nonMatch)
+
+        let matches = manager.matchPeers(for: origin, radius: 2000.0, limit: 2)
+        XCTAssertEqual(matches.count, 2)
+        XCTAssertEqual(matches[0], nearMatch)
+        XCTAssertEqual(matches[1], farMatch)
+    }
+
+    func testPrunesStalePeers() {
+        let manager = PeerManager()
+        let fresh = Peer(latitude: 0.0, longitude: 0.0)
+        let stale = Peer(latitude: 0.0, longitude: 0.0, lastSeen: Date(timeIntervalSinceNow: -7200))
+        manager.add(fresh)
+        manager.add(stale)
+
+        manager.pruneStale(before: Date(timeIntervalSinceNow: -3600))
+
+        XCTAssertEqual(manager.allPeers(), [fresh])
+    }
+
+    func testUpdateLastSeenChangesTimestamp() {
+        let manager = PeerManager()
+        let oldDate = Date(timeIntervalSince1970: 0)
+        let peer = Peer(latitude: 0.0, longitude: 0.0, lastSeen: oldDate)
+        manager.add(peer)
+
+        let newDate = Date(timeIntervalSince1970: 100)
+        manager.updateLastSeen(id: peer.id, at: newDate)
+
+        let updated = manager.peer(id: peer.id)
+        XCTAssertEqual(updated?.lastSeen, newDate)
+    }
+
+    func testPersistenceRoundTrip() throws {
+        let manager = PeerManager()
+        let timestamp = Date(timeIntervalSince1970: 1234)
+        let peer = Peer(latitude: 1.0, longitude: 2.0, lastSeen: timestamp)
+        manager.add(peer)
+
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        let store = PeerStore(url: tmp)
+        try manager.save(to: store)
+
+        let restored = PeerManager()
+        try restored.load(from: store)
+        XCTAssertEqual(restored.allPeers(), [peer])
+        XCTAssertEqual(restored.peer(id: peer.id)?.lastSeen, timestamp)
+    }
+
+    func testBlockedPeersPersistThroughStore() throws {
+        let manager = PeerManager()
+        let peer = Peer(latitude: 0.0, longitude: 0.0)
+        manager.add(peer)
+        manager.block(id: peer.id)
+
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        let store = PeerStore(url: tmp)
+        try manager.save(to: store)
+
+        let restored = PeerManager()
+        try restored.load(from: store)
+
+        XCTAssertEqual(restored.allPeers().count, 0)
+        restored.unblock(id: peer.id)
+        XCTAssertEqual(restored.allPeers(), [peer])
+    }
+
+    func testLikedPeersAreReturned() {
+        let manager = PeerManager()
+        let peer = Peer(latitude: 0.0, longitude: 0.0)
+        manager.add(peer)
+        manager.like(id: peer.id)
+
+        XCTAssertEqual(manager.likedPeers(), [peer])
+
+        manager.block(id: peer.id)
+        XCTAssertTrue(manager.likedPeers().isEmpty)
+    }
+
+    func testLikedPeersPersistThroughStore() throws {
+        let manager = PeerManager()
+        let peer = Peer(latitude: 0.0, longitude: 0.0)
+        manager.add(peer)
+        manager.like(id: peer.id)
+
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        let store = PeerStore(url: tmp)
+        try manager.save(to: store)
+
+        let restored = PeerManager()
+        try restored.load(from: store)
+
+        XCTAssertEqual(restored.likedPeers(), [peer])
+    }
+
+    func testMutualLikesReturnPeersWhoLikeUser() {
+        let manager = PeerManager()
+        let myID = UUID()
+        let liker = Peer(latitude: 0.0, longitude: 0.0, attributes: ["likes": myID.uuidString])
+        let nonLiker = Peer(latitude: 0.0, longitude: 0.0)
+        manager.add(liker)
+        manager.add(nonLiker)
+        manager.like(id: liker.id)
+        manager.like(id: nonLiker.id)
+
+        let matches = manager.mutualLikes(for: myID)
+        XCTAssertEqual(matches, [liker])
+    }
+
+    func testBlockedPeersAreExcludedFromQueries() {
+        let manager = PeerManager()
+        let first = Peer(latitude: 0.0, longitude: 0.0)
+        let second = Peer(latitude: 0.0, longitude: 0.0)
+        manager.add(first)
+        manager.add(second)
+
+        manager.block(id: second.id)
+
+        XCTAssertEqual(manager.allPeers(), [first])
+        XCTAssertFalse(manager.peers(near: 0.0, longitude: 0.0, radius: 1.0).contains(second))
+
+        manager.unblock(id: second.id)
+        let all = manager.allPeers()
+        XCTAssertTrue(all.contains(first))
+        XCTAssertTrue(all.contains(second))
+    }
+
+    func testConnectUpdatesLastSeen() {
+        let manager = PeerManager()
+        let oldDate = Date(timeIntervalSince1970: 0)
+        let peer = Peer(latitude: 0.0, longitude: 0.0, lastSeen: oldDate)
+        manager.add(peer)
+
+        let success = manager.connect(to: peer.id)
+        XCTAssertTrue(success)
+        let updated = manager.peer(id: peer.id)
+        XCTAssertNotEqual(updated?.lastSeen, oldDate)
+    }
+
+    func testConnectFailsForBlockedPeer() {
+        let manager = PeerManager()
+        let peer = Peer(latitude: 0.0, longitude: 0.0)
+        manager.add(peer)
+        manager.block(id: peer.id)
+
+        XCTAssertFalse(manager.connect(to: peer.id))
+    }
+
+    func testGeohashEncoding() {
+        let sf = Peer(latitude: 37.7749, longitude: -122.4194)
+        XCTAssertEqual(sf.geohash, "9q8yyk8y")
+    }
+
+    func testPeersInGeohashPrefix() {
+        let manager = PeerManager()
+        let sf = Peer(latitude: 37.7749, longitude: -122.4194)
+        let la = Peer(latitude: 34.0522, longitude: -118.2437)
+        manager.add(sf)
+        manager.add(la)
+
+        let prefix = String(sf.geohash.prefix(5))
+        let results = manager.peers(inGeohash: prefix)
+        XCTAssertEqual(results, [sf])
+    }
+
+    func testPeersInGeohashPrefixWithAttributeFilter() {
+        let manager = PeerManager()
+        let sfHiker = Peer(latitude: 37.7749, longitude: -122.4194, attributes: ["hobby": "hiking"])
+        let sfBaker = Peer(latitude: 37.7750, longitude: -122.4195, attributes: ["hobby": "baking"])
+        let laHiker = Peer(latitude: 34.0522, longitude: -118.2437, attributes: ["hobby": "hiking"])
+        manager.add(sfHiker)
+        manager.add(sfBaker)
+        manager.add(laHiker)
+
+        let prefix = String(sfHiker.geohash.prefix(5))
+        let results = manager.peers(inGeohash: prefix, matching: ["hobby": "hiking"])
+        XCTAssertEqual(results, [sfHiker])
+    }
+
+    func testRecentPeersReturnsMostRecentFirst() {
+        let manager = PeerManager()
+        let older = Peer(latitude: 0.0, longitude: 0.0, lastSeen: Date(timeIntervalSinceNow: -3600))
+        let newer = Peer(latitude: 0.0, longitude: 0.0)
+        let blocked = Peer(latitude: 0.0, longitude: 0.0)
+
+        manager.add(older)
+        manager.add(newer)
+        manager.add(blocked)
+        manager.block(id: blocked.id)
+
+        let results = manager.recentPeers(limit: 5)
+        XCTAssertEqual(results, [newer, older])
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a placeholder `P2PNode` that will later integrate libp2p and track bootstrap peers
- document the planned technology stack for the Weave iOS app
- demonstrate starting the node in the CLI example and cover it with a basic unit test
- add optional display names for peers with an `updateName` helper and CLI/test coverage
- track liked peers with `like`/`unlike` helpers, persist them via `PeerStore`, and exercise the flow in the demo and tests
- detect mutual likes by checking liked peers for a matching `likes` attribute
- support attribute-filtered geohash queries with demo and unit test

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_688f7e3343d8832b90aea8eb3899a183