### PR TITLE
Secure peer store with AES-GCM encryption

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,12 +10,15 @@ let package = Package(
     ],
     dependencies: [
         // TODO: Add libp2p dependency when available.
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "2.7.0")
     ],
     targets: [
         // Targets define modules or test suites.
         .executableTarget(
             name: "weave",
-            dependencies: []),
+            dependencies: [
+                .product(name: "Crypto", package: "swift-crypto")
+            ]),
         .testTarget(
             name: "WeaveTests",
             dependencies: ["weave"])

--- a/Sources/PeerStore.swift
+++ b/Sources/PeerStore.swift
@@ -1,4 +1,17 @@
 import Foundation
+#if canImport(CryptoKit)
+import CryptoKit
+#else
+import Crypto
+#endif
+#if canImport(Security)
+import Security
+#else
+// On platforms without the Security framework (e.g. Linux), declare a
+// compatible alias so the code can compile. The key is stored using
+// `UserDefaults` in this case which is not as secure but keeps tests running.
+typealias OSStatus = Int32
+#endif
 
 /// Persists and restores peers (and the block/liked lists) to and from disk using JSON
 /// encoding.
@@ -17,12 +30,89 @@ struct PeerStore {
         }
     }
 
+    /// Errors that can be thrown by `PeerStore`.
+    enum StoreError: Error, LocalizedError {
+        case keychainError(OSStatus)
+        case encryptionFailed
+        case decryptionFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .keychainError(let status):
+#if canImport(Security)
+                if let message = SecCopyErrorMessageString(status, nil) as String? {
+                    return message
+                }
+#endif
+                return "Keychain operation failed with status \(status)"
+            case .encryptionFailed:
+                return "Failed to encrypt data"
+            case .decryptionFailed:
+                return "Failed to decrypt data"
+            }
+        }
+    }
+
+    private static let keyTag = "com.weave.peerstorekey"
+
+    /// Retrieves an existing encryption key or creates one if needed. On Apple
+    /// platforms the key is stored in the Keychain; elsewhere a less secure
+    /// `UserDefaults` storage is used for testing purposes.
+    private func loadOrCreateKey() throws -> SymmetricKey {
+#if canImport(Security)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: Self.keyTag,
+            kSecReturnData as String: true
+        ]
+        var item: CFTypeRef?
+        var status = SecItemCopyMatching(query as CFDictionary, &item)
+
+        if status == errSecSuccess, let data = item as? Data {
+            return SymmetricKey(data: data)
+        }
+
+        guard status == errSecItemNotFound else {
+            throw StoreError.keychainError(status)
+        }
+
+        let key = SymmetricKey(size: .bits256)
+        let data = key.withUnsafeBytes { Data($0) }
+        let addQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: Self.keyTag,
+            kSecValueData as String: data
+        ]
+        status = SecItemAdd(addQuery as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw StoreError.keychainError(status)
+        }
+        return key
+#else
+        let defaults = UserDefaults.standard
+        if let data = defaults.data(forKey: Self.keyTag) {
+            return SymmetricKey(data: data)
+        }
+        let key = SymmetricKey(size: .bits256)
+        let data = key.withUnsafeBytes { Data($0) }
+        defaults.set(data, forKey: Self.keyTag)
+        return key
+#endif
+    }
+
     /// Saves the provided peers and blocked/liked IDs to disk, overwriting any
-    /// existing file.
+    /// existing file. Data is encrypted using AES.GCM before being written.
     func save(peers: [Peer], blocked: [UUID], liked: [UUID] = []) throws {
         let snapshot = Snapshot(peers: peers, blocked: blocked, liked: liked)
         let data = try JSONEncoder().encode(snapshot)
-        try data.write(to: url, options: .atomic)
+        let key = try loadOrCreateKey()
+        let sealedBox: AES.GCM.SealedBox
+        do {
+            sealedBox = try AES.GCM.seal(data, using: key)
+        } catch {
+            throw StoreError.encryptionFailed
+        }
+        try sealedBox.combined.write(to: url, options: .atomic)
     }
 
     /// Loads peers and blocked/liked IDs from disk. Returns empty collections if the
@@ -31,11 +121,25 @@ struct PeerStore {
     func load() throws -> (peers: [Peer], blocked: [UUID], liked: [UUID]) {
         guard FileManager.default.fileExists(atPath: url.path) else { return ([], [], []) }
         let data = try Data(contentsOf: url)
-        if let snapshot = try? JSONDecoder().decode(Snapshot.self, from: data) {
-            return (snapshot.peers, snapshot.blocked, snapshot.liked)
+        let key = try loadOrCreateKey()
+
+        do {
+            let box = try AES.GCM.SealedBox(combined: data)
+            let decrypted = try AES.GCM.open(box, using: key)
+            if let snapshot = try? JSONDecoder().decode(Snapshot.self, from: decrypted) {
+                return (snapshot.peers, snapshot.blocked, snapshot.liked)
+            }
+        } catch {
+            // Fallback: attempt to decode plain JSON for backward compatibility
+            if let snapshot = try? JSONDecoder().decode(Snapshot.self, from: data) {
+                return (snapshot.peers, snapshot.blocked, snapshot.liked)
+            }
+            if let peers = try? JSONDecoder().decode([Peer].self, from: data) {
+                return (peers, [], [])
+            }
+            throw StoreError.decryptionFailed
         }
 
-        let peers = try JSONDecoder().decode([Peer].self, from: data)
-        return (peers, [], [])
+        throw StoreError.decryptionFailed
     }
 }

--- a/Tests/WeaveTests/PeerStoreTests.swift
+++ b/Tests/WeaveTests/PeerStoreTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import weave
+
+final class PeerStoreTests: XCTestCase {
+    func testEncryptedSaveLoadRoundTrip() throws {
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let store = PeerStore(url: tempURL)
+        let peer = Peer(latitude: 10.0, longitude: 20.0, attributes: ["foo": "bar"])
+        let blocked = [UUID()]
+        let liked = [UUID()]
+        try store.save(peers: [peer], blocked: blocked, liked: liked)
+        let (loadedPeers, loadedBlocked, loadedLiked) = try store.load()
+        XCTAssertEqual(loadedPeers, [peer])
+        XCTAssertEqual(loadedBlocked, blocked)
+        XCTAssertEqual(loadedLiked, liked)
+
+        let data = try Data(contentsOf: tempURL)
+        XCTAssertThrowsError(try JSONDecoder().decode([Peer].self, from: data))
+    }
+}


### PR DESCRIPTION
## Summary
- Encrypt peer data using AES.GCM with per-device key stored in the Keychain or UserDefaults fallback
- Surface keychain and crypto failures via explicit `PeerStore.StoreError`
- Add package dependency and tests for encrypted save/load round trips

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/apple/swift-crypto.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688fa9678980832bbec753d136a84928