### PR TITLE
Validate peer coordinate ranges

### DIFF
--- a/Sources/Peer.swift
+++ b/Sources/Peer.swift
@@ -4,6 +4,11 @@ import Foundation
 /// Peers are identified by a unique ID and may advertise
 /// a network address and their geographic location.
 struct Peer: Identifiable, Codable, Equatable {
+    enum PeerError: Error {
+        case invalidLatitude(Double)
+        case invalidLongitude(Double)
+    }
+
     let id: UUID
 
     /// Optional human-friendly display name.
@@ -33,7 +38,14 @@ struct Peer: Identifiable, Codable, Equatable {
          longitude: Double,
 
          attributes: [String: String] = [:],
-         lastSeen: Date = Date()) {
+         lastSeen: Date = Date()) throws {
+        guard (-90.0...90.0).contains(latitude) else {
+            throw PeerError.invalidLatitude(latitude)
+        }
+        guard (-180.0...180.0).contains(longitude) else {
+            throw PeerError.invalidLongitude(longitude)
+        }
+
         self.id = id
         self.name = name
 

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -13,14 +13,14 @@ let manager = PeerManager()
 let selfLat = 37.7749
 let selfLon = -122.4194
 
-let me = Peer(name: "Me", latitude: selfLat, longitude: selfLon, attributes: ["hobby": "hiking"])
+let me = try! Peer(name: "Me", latitude: selfLat, longitude: selfLon, attributes: ["hobby": "hiking"])
 
 // Add a peer in San Francisco
-let movingPeer = Peer(name: "Alice", latitude: 37.7750, longitude: -122.4183, attributes: ["hobby": "hiking", "likes": me.id.uuidString])
+let movingPeer = try! Peer(name: "Alice", latitude: 37.7750, longitude: -122.4183, attributes: ["hobby": "hiking", "likes": me.id.uuidString])
 manager.add(movingPeer)
 
 // Add another peer in Los Angeles with the same hobby
-let laPeer = Peer(name: "Bob", latitude: 34.0522, longitude: -118.2437, attributes: ["hobby": "hiking"])
+let laPeer = try! Peer(name: "Bob", latitude: 34.0522, longitude: -118.2437, attributes: ["hobby": "hiking"])
 manager.add(laPeer)
 
 // Query peers sharing the same geohash prefix as the moving peer (coarse area match)
@@ -95,7 +95,7 @@ restored.unblock(id: laPeer.id)
 print("After unblocking LA user post-restore: \(restored.allPeers().count) peer(s)")
 
 // Demonstrate pruning stale peers
-let stalePeer = Peer(latitude: 35.0, longitude: -120.0, lastSeen: Date(timeIntervalSinceNow: -7200))
+let stalePeer = try! Peer(latitude: 35.0, longitude: -120.0, lastSeen: Date(timeIntervalSinceNow: -7200))
 manager.add(stalePeer)
 print("Total peers before pruning: \(manager.allPeers().count)")
 manager.pruneStale(before: Date(timeIntervalSinceNow: -3600))

--- a/Tests/WeaveTests/PeerManagerTests.swift
+++ b/Tests/WeaveTests/PeerManagerTests.swift
@@ -7,9 +7,9 @@ final class PeerManagerTests: XCTestCase {
     func testFiltersNearbyPeers() {
 
         let manager = PeerManager()
-        let userLocation = Peer(latitude: 37.7749, longitude: -122.4194)
-        let nearby = Peer(latitude: 37.7750, longitude: -122.4195)
-        let farAway = Peer(latitude: 40.7128, longitude: -74.0060)
+        let userLocation = try! Peer(latitude: 37.7749, longitude: -122.4194)
+        let nearby = try! Peer(latitude: 37.7750, longitude: -122.4195)
+        let farAway = try! Peer(latitude: 40.7128, longitude: -74.0060)
 
         manager.add(nearby)
         manager.add(farAway)
@@ -22,7 +22,7 @@ final class PeerManagerTests: XCTestCase {
 
     func testRemovingPeerUpdatesIndex() {
         let manager = PeerManager()
-        let peer = Peer(latitude: 37.0, longitude: -122.0)
+        let peer = try! Peer(latitude: 37.0, longitude: -122.0)
         manager.add(peer)
         XCTAssertEqual(manager.allPeers().count, 1)
         manager.remove(id: peer.id)
@@ -31,9 +31,9 @@ final class PeerManagerTests: XCTestCase {
 
     func testNearestPeersReturnsSortedResults() {
         let manager = PeerManager()
-        let origin = Peer(latitude: 0.0, longitude: 0.0)
-        let nearer = Peer(latitude: 0.0, longitude: 0.05) // ~5.5km east
-        let near = Peer(latitude: 0.0, longitude: 0.1)   // ~11km east
+        let origin = try! Peer(latitude: 0.0, longitude: 0.0)
+        let nearer = try! Peer(latitude: 0.0, longitude: 0.05) // ~5.5km east
+        let near = try! Peer(latitude: 0.0, longitude: 0.1)   // ~11km east
 
         manager.add(near)
         manager.add(nearer)
@@ -47,9 +47,9 @@ final class PeerManagerTests: XCTestCase {
 
     func testNearestPeersRespectsAttributeFilters() {
         let manager = PeerManager()
-        let origin = Peer(latitude: 0.0, longitude: 0.0)
-        let hikingPeer = Peer(latitude: 0.0, longitude: 0.05, attributes: ["hobby": "hiking"])
-        let gamingPeer = Peer(latitude: 0.0, longitude: 0.02, attributes: ["hobby": "gaming"])
+        let origin = try! Peer(latitude: 0.0, longitude: 0.0)
+        let hikingPeer = try! Peer(latitude: 0.0, longitude: 0.05, attributes: ["hobby": "hiking"])
+        let gamingPeer = try! Peer(latitude: 0.0, longitude: 0.02, attributes: ["hobby": "gaming"])
 
         manager.add(hikingPeer)
         manager.add(gamingPeer)
@@ -64,8 +64,8 @@ final class PeerManagerTests: XCTestCase {
 
     func testAttributeFilteringReturnsMatches() {
         let manager = PeerManager()
-        let hiker = Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "hiking"])
-        let gamer = Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "gaming"])
+        let hiker = try! Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "hiking"])
+        let gamer = try! Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "gaming"])
 
         manager.add(hiker)
         manager.add(gamer)
@@ -77,7 +77,7 @@ final class PeerManagerTests: XCTestCase {
 
     func testUpdatingPeerLocation() {
         let manager = PeerManager()
-        let peer = Peer(latitude: 0.0, longitude: 0.0)
+        let peer = try! Peer(latitude: 0.0, longitude: 0.0)
         manager.add(peer)
         manager.updateLocation(id: peer.id, latitude: 1.0, longitude: 1.0)
         let updated = manager.peer(id: peer.id)
@@ -87,7 +87,7 @@ final class PeerManagerTests: XCTestCase {
 
     func testUpdatingPeerAttributes() {
         let manager = PeerManager()
-        let peer = Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "gaming"])
+        let peer = try! Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "gaming"])
         manager.add(peer)
         manager.updateAttributes(id: peer.id, attributes: ["hobby": "hiking"])
         let updated = manager.peer(id: peer.id)
@@ -96,7 +96,7 @@ final class PeerManagerTests: XCTestCase {
 
     func testUpdatingSingleAttribute() {
         let manager = PeerManager()
-        let peer = Peer(latitude: 0.0, longitude: 0.0)
+        let peer = try! Peer(latitude: 0.0, longitude: 0.0)
         manager.add(peer)
         manager.updateAttribute(id: peer.id, key: "hobby", value: "chess")
         let updated = manager.peer(id: peer.id)
@@ -105,7 +105,7 @@ final class PeerManagerTests: XCTestCase {
 
     func testRemovingAttribute() {
         let manager = PeerManager()
-        let peer = Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "chess"])
+        let peer = try! Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "chess"])
         manager.add(peer)
         manager.removeAttribute(id: peer.id, key: "hobby")
         let updated = manager.peer(id: peer.id)
@@ -114,7 +114,7 @@ final class PeerManagerTests: XCTestCase {
 
     func testUpdatingPeerAddress() {
         let manager = PeerManager()
-        let peer = Peer(address: "1.2.3.4", port: 1000, latitude: 0.0, longitude: 0.0)
+        let peer = try! Peer(address: "1.2.3.4", port: 1000, latitude: 0.0, longitude: 0.0)
         manager.add(peer)
         manager.updateAddress(id: peer.id, address: "5.6.7.8", port: 2000)
         let updated = manager.peer(id: peer.id)
@@ -124,7 +124,7 @@ final class PeerManagerTests: XCTestCase {
 
     func testUpdatingPeerName() {
         let manager = PeerManager()
-        let peer = Peer(name: "Old", latitude: 0.0, longitude: 0.0)
+        let peer = try! Peer(name: "Old", latitude: 0.0, longitude: 0.0)
         manager.add(peer)
         manager.updateName(id: peer.id, name: "New")
         let updated = manager.peer(id: peer.id)
@@ -134,10 +134,10 @@ final class PeerManagerTests: XCTestCase {
 
     func testMatchPeersRanksByAttributeScoreThenDistance() {
         let manager = PeerManager()
-        let origin = Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "hiking"])
-        let nearMatch = Peer(latitude: 0.0, longitude: 0.05, attributes: ["hobby": "hiking"])
-        let farMatch = Peer(latitude: 0.0, longitude: 1.0, attributes: ["hobby": "hiking"])
-        let nonMatch = Peer(latitude: 0.0, longitude: 0.05, attributes: ["hobby": "gaming"])
+        let origin = try! Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "hiking"])
+        let nearMatch = try! Peer(latitude: 0.0, longitude: 0.05, attributes: ["hobby": "hiking"])
+        let farMatch = try! Peer(latitude: 0.0, longitude: 1.0, attributes: ["hobby": "hiking"])
+        let nonMatch = try! Peer(latitude: 0.0, longitude: 0.05, attributes: ["hobby": "gaming"])
 
         manager.add(nearMatch)
         manager.add(farMatch)
@@ -151,8 +151,8 @@ final class PeerManagerTests: XCTestCase {
 
     func testPrunesStalePeers() {
         let manager = PeerManager()
-        let fresh = Peer(latitude: 0.0, longitude: 0.0)
-        let stale = Peer(latitude: 0.0, longitude: 0.0, lastSeen: Date(timeIntervalSinceNow: -7200))
+        let fresh = try! Peer(latitude: 0.0, longitude: 0.0)
+        let stale = try! Peer(latitude: 0.0, longitude: 0.0, lastSeen: Date(timeIntervalSinceNow: -7200))
         manager.add(fresh)
         manager.add(stale)
 
@@ -164,7 +164,7 @@ final class PeerManagerTests: XCTestCase {
     func testUpdateLastSeenChangesTimestamp() {
         let manager = PeerManager()
         let oldDate = Date(timeIntervalSince1970: 0)
-        let peer = Peer(latitude: 0.0, longitude: 0.0, lastSeen: oldDate)
+        let peer = try! Peer(latitude: 0.0, longitude: 0.0, lastSeen: oldDate)
         manager.add(peer)
 
         let newDate = Date(timeIntervalSince1970: 100)
@@ -177,7 +177,7 @@ final class PeerManagerTests: XCTestCase {
     func testPersistenceRoundTrip() throws {
         let manager = PeerManager()
         let timestamp = Date(timeIntervalSince1970: 1234)
-        let peer = Peer(latitude: 1.0, longitude: 2.0, lastSeen: timestamp)
+        let peer = try! Peer(latitude: 1.0, longitude: 2.0, lastSeen: timestamp)
         manager.add(peer)
 
         let tmp = FileManager.default.temporaryDirectory
@@ -193,7 +193,7 @@ final class PeerManagerTests: XCTestCase {
 
     func testBlockedPeersPersistThroughStore() throws {
         let manager = PeerManager()
-        let peer = Peer(latitude: 0.0, longitude: 0.0)
+        let peer = try! Peer(latitude: 0.0, longitude: 0.0)
         manager.add(peer)
         manager.block(id: peer.id)
 
@@ -212,7 +212,7 @@ final class PeerManagerTests: XCTestCase {
 
     func testLikedPeersAreReturned() {
         let manager = PeerManager()
-        let peer = Peer(latitude: 0.0, longitude: 0.0)
+        let peer = try! Peer(latitude: 0.0, longitude: 0.0)
         manager.add(peer)
         manager.like(id: peer.id)
 
@@ -224,7 +224,7 @@ final class PeerManagerTests: XCTestCase {
 
     func testLikedPeersPersistThroughStore() throws {
         let manager = PeerManager()
-        let peer = Peer(latitude: 0.0, longitude: 0.0)
+        let peer = try! Peer(latitude: 0.0, longitude: 0.0)
         manager.add(peer)
         manager.like(id: peer.id)
 
@@ -242,8 +242,8 @@ final class PeerManagerTests: XCTestCase {
     func testMutualLikesReturnPeersWhoLikeUser() {
         let manager = PeerManager()
         let myID = UUID()
-        let liker = Peer(latitude: 0.0, longitude: 0.0, attributes: ["likes": myID.uuidString])
-        let nonLiker = Peer(latitude: 0.0, longitude: 0.0)
+        let liker = try! Peer(latitude: 0.0, longitude: 0.0, attributes: ["likes": myID.uuidString])
+        let nonLiker = try! Peer(latitude: 0.0, longitude: 0.0)
         manager.add(liker)
         manager.add(nonLiker)
         manager.like(id: liker.id)
@@ -255,8 +255,8 @@ final class PeerManagerTests: XCTestCase {
 
     func testBlockedPeersAreExcludedFromQueries() {
         let manager = PeerManager()
-        let first = Peer(latitude: 0.0, longitude: 0.0)
-        let second = Peer(latitude: 0.0, longitude: 0.0)
+        let first = try! Peer(latitude: 0.0, longitude: 0.0)
+        let second = try! Peer(latitude: 0.0, longitude: 0.0)
         manager.add(first)
         manager.add(second)
 
@@ -274,7 +274,7 @@ final class PeerManagerTests: XCTestCase {
     func testConnectUpdatesLastSeen() {
         let manager = PeerManager()
         let oldDate = Date(timeIntervalSince1970: 0)
-        let peer = Peer(latitude: 0.0, longitude: 0.0, lastSeen: oldDate)
+        let peer = try! Peer(latitude: 0.0, longitude: 0.0, lastSeen: oldDate)
         manager.add(peer)
 
         let success = manager.connect(to: peer.id)
@@ -285,7 +285,7 @@ final class PeerManagerTests: XCTestCase {
 
     func testConnectFailsForBlockedPeer() {
         let manager = PeerManager()
-        let peer = Peer(latitude: 0.0, longitude: 0.0)
+        let peer = try! Peer(latitude: 0.0, longitude: 0.0)
         manager.add(peer)
         manager.block(id: peer.id)
 
@@ -293,14 +293,14 @@ final class PeerManagerTests: XCTestCase {
     }
 
     func testGeohashEncoding() {
-        let sf = Peer(latitude: 37.7749, longitude: -122.4194)
+        let sf = try! Peer(latitude: 37.7749, longitude: -122.4194)
         XCTAssertEqual(sf.geohash, "9q8yyk8y")
     }
 
     func testPeersInGeohashPrefix() {
         let manager = PeerManager()
-        let sf = Peer(latitude: 37.7749, longitude: -122.4194)
-        let la = Peer(latitude: 34.0522, longitude: -118.2437)
+        let sf = try! Peer(latitude: 37.7749, longitude: -122.4194)
+        let la = try! Peer(latitude: 34.0522, longitude: -118.2437)
         manager.add(sf)
         manager.add(la)
 
@@ -311,9 +311,9 @@ final class PeerManagerTests: XCTestCase {
 
     func testRecentPeersReturnsMostRecentFirst() {
         let manager = PeerManager()
-        let older = Peer(latitude: 0.0, longitude: 0.0, lastSeen: Date(timeIntervalSinceNow: -3600))
-        let newer = Peer(latitude: 0.0, longitude: 0.0)
-        let blocked = Peer(latitude: 0.0, longitude: 0.0)
+        let older = try! Peer(latitude: 0.0, longitude: 0.0, lastSeen: Date(timeIntervalSinceNow: -3600))
+        let newer = try! Peer(latitude: 0.0, longitude: 0.0)
+        let blocked = try! Peer(latitude: 0.0, longitude: 0.0)
 
         manager.add(older)
         manager.add(newer)

--- a/Tests/WeaveTests/PeerTests.swift
+++ b/Tests/WeaveTests/PeerTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import weave
+
+final class PeerTests: XCTestCase {
+    func testInvalidLatitudeThrows() {
+        XCTAssertThrowsError(try Peer(latitude: 100, longitude: 0)) { error in
+            guard case Peer.PeerError.invalidLatitude = error else {
+                XCTFail("Expected invalidLatitude error")
+                return
+            }
+        }
+    }
+
+    func testInvalidLongitudeThrows() {
+        XCTAssertThrowsError(try Peer(latitude: 0, longitude: 200)) { error in
+            guard case Peer.PeerError.invalidLongitude = error else {
+                XCTFail("Expected invalidLongitude error")
+                return
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `PeerError` and validate latitude and longitude in `Peer` initializer
- update call sites for throwing initializer
- add tests for invalid coordinate scenarios

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_688fa96ce4bc832b84d8342541d2f448