### PR TITLE
Cache distances when sorting nearest peers

### DIFF
--- a/Sources/PeerManager.swift
+++ b/Sources/PeerManager.swift
@@ -167,16 +167,19 @@ class PeerManager {
                       longitude: Double,
                       limit: Int,
                       matching filters: [String: String] = [:]) -> [Peer] {
-        let sorted = peerIndex.values
+        let candidates = peerIndex.values
             .filter { peer in
                 !blocked.contains(peer.id) &&
                 filters.allSatisfy { key, value in peer.attributes[key] == value }
             }
-            .sorted {
-                distance(from: (latitude, longitude), to: ($0.latitude, $0.longitude)) <
-                distance(from: (latitude, longitude), to: ($1.latitude, $1.longitude))
+            .map { peer -> (peer: Peer, distance: Double) in
+                let dist = distance(from: (latitude, longitude),
+                                    to: (peer.latitude, peer.longitude))
+                return (peer, dist)
             }
-        return Array(sorted.prefix(limit))
+            .sorted { $0.distance < $1.distance }
+
+        return candidates.prefix(limit).map { $0.peer }
     }
 
     /// Returns up to `limit` most recently seen peers, excluding any that are blocked.

--- a/Tests/WeaveTests/PeerManagerTests.swift
+++ b/Tests/WeaveTests/PeerManagerTests.swift
@@ -62,6 +62,42 @@ final class PeerManagerTests: XCTestCase {
 
     }
 
+    func testNearestPeersMatchesNaiveImplementation() {
+        let manager = PeerManager()
+        let originLat = 0.0
+        let originLon = 0.0
+
+        let peers = [
+            Peer(latitude: 0.0, longitude: 0.3),
+            Peer(latitude: 0.0, longitude: 0.1),
+            Peer(latitude: 0.0, longitude: -0.1),
+            Peer(latitude: 0.2, longitude: 0.0),
+            Peer(latitude: -0.2, longitude: 0.0)
+        ]
+
+        peers.forEach { manager.add($0) }
+
+        let optimized = manager.nearestPeers(to: originLat, longitude: originLon, limit: 5)
+
+        func distance(_ from: (Double, Double), _ to: (Double, Double)) -> Double {
+            let earthRadiusKm = 6371.0
+            let deltaLat = (to.0 - from.0) * Double.pi / 180
+            let deltaLon = (to.1 - from.1) * Double.pi / 180
+            let a = sin(deltaLat/2) * sin(deltaLat/2) +
+                    cos(from.0 * Double.pi / 180) * cos(to.0 * Double.pi / 180) *
+                    sin(deltaLon/2) * sin(deltaLon/2)
+            let c = 2 * atan2(sqrt(a), sqrt(1-a))
+            return earthRadiusKm * c
+        }
+
+        let naive = manager.allPeers().sorted {
+            distance((originLat, originLon), ($0.latitude, $0.longitude)) <
+            distance((originLat, originLon), ($1.latitude, $1.longitude))
+        }
+
+        XCTAssertEqual(optimized, Array(naive.prefix(5)))
+    }
+
     func testAttributeFilteringReturnsMatches() {
         let manager = PeerManager()
         let hiker = Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "hiking"])


### PR DESCRIPTION
## Summary
- cache computed distances when finding nearest peers to avoid repeated calculations
- add regression test ensuring optimized nearest-peers search matches naive sort

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_688fa96db350832ba5d761111a12dbb4