### PR TITLE
Filter stale peers from liked list

### DIFF
--- a/Sources/PeerManager.swift
+++ b/Sources/PeerManager.swift
@@ -267,6 +267,7 @@ final class PeerManager: @unchecked Sendable {
         queue.sync(flags: .barrier) {
             peerIndex = peerIndex.filter { $0.value.lastSeen >= cutoff }
             blocked = blocked.filter { peerIndex[$0] != nil }
+            liked = liked.filter { peerIndex[$0] != nil }
         }
 
     }

--- a/Tests/WeaveTests/PeerManagerTests.swift
+++ b/Tests/WeaveTests/PeerManagerTests.swift
@@ -198,6 +198,20 @@ final class PeerManagerTests: XCTestCase {
         XCTAssertEqual(manager.allPeers(), [fresh])
     }
 
+    func testPruneStaleRemovesLikedPeers() {
+        let manager = PeerManager()
+        let fresh = try! Peer(latitude: 0.0, longitude: 0.0)
+        let stale = try! Peer(latitude: 0.0, longitude: 0.0, lastSeen: Date(timeIntervalSinceNow: -7200))
+        manager.add(fresh)
+        manager.add(stale)
+        manager.like(id: fresh.id)
+        manager.like(id: stale.id)
+
+        manager.pruneStale(before: Date(timeIntervalSinceNow: -3600))
+
+        XCTAssertEqual(manager.likedPeers(), [fresh])
+    }
+
     func testUpdateLastSeenChangesTimestamp() {
         let manager = PeerManager()
         let oldDate = Date(timeIntervalSince1970: 0)


### PR DESCRIPTION
## Summary
- ensure `pruneStale` removes IDs of stale peers from `liked`
- add regression test for pruning stale liked peers

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/apple/swift-crypto.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688faed2c248832bb2f2cb3e2203a85c