### PR TITLE
Add libp2p host scaffolding

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .executable(name: "weave", targets: ["weave"])
     ],
     dependencies: [
-        // TODO: Add libp2p dependency when available.
+        .package(url: "https://github.com/libp2p/swift-libp2p.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "2.7.0")
     ],
     targets: [
@@ -17,7 +17,9 @@ let package = Package(
         .executableTarget(
             name: "weave",
             dependencies: [
-                .product(name: "Crypto", package: "swift-crypto")
+                .product(name: "Crypto", package: "swift-crypto"),
+                // Once released, this product will expose the libp2p host implementation.
+                .product(name: "LibP2P", package: "swift-libp2p")
             ]),
         .testTarget(
             name: "WeaveTests",

--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -1,25 +1,69 @@
 import Foundation
 
-/// A placeholder networking node that will integrate libp2p in the future.
-/// For now it simply tracks bootstrap peers and whether the node is running.
+#if canImport(LibP2P)
+import LibP2P
+#endif
+
+/// Abstraction over the underlying libp2p host so it can be mocked in tests.
+protocol LibP2PHosting {
+    /// Start listening for connections and initialise any required services.
+    func start()
+    /// Connect to a set of bootstrap peers to join the network.
+    func bootstrap(peers: [String])
+    /// Enable NAT traversal so the node is reachable from the public internet.
+    func enableNAT()
+    /// Shut down the host and release any resources.
+    func stop()
+}
+
+/// Default no-op implementation used until a real libp2p host is wired in.
+struct NoopLibP2PHost: LibP2PHosting {
+    func start() {}
+    func bootstrap(peers: [String]) {}
+    func enableNAT() {}
+    func stop() {}
+}
+
+/// A networking node backed by a libp2p host.
+/// The node is initialised with a list of bootstrap peers and is responsible
+/// for starting and stopping the underlying host.
 final class P2PNode {
     /// Addresses of peers used to join the wider network.
     private let bootstrapPeers: [String]
+    /// Factory used to create the libp2p host. Injected to allow mocking in tests.
+    private let hostBuilder: () -> LibP2PHosting
+    /// The underlying libp2p host instance once started.
+    private var host: LibP2PHosting?
     /// Indicates whether the node is actively running.
     private(set) var isRunning: Bool = false
 
-    init(bootstrapPeers: [String] = []) {
+    init(bootstrapPeers: [String] = [], hostBuilder: @escaping () -> LibP2PHosting = { NoopLibP2PHost() }) {
         self.bootstrapPeers = bootstrapPeers
+        self.hostBuilder = hostBuilder
     }
 
-    /// Starts the networking stack. In a real implementation this would
-    /// initialise libp2p, perform NAT traversal and begin listening for peers.
+    /// Starts the networking stack by creating a libp2p host, performing
+    /// bootstrap against known peers and enabling NAT traversal.
     func start() {
+        guard !isRunning else { return }
+
+        let host = hostBuilder()
+        self.host = host
+
+        host.start()
+        if !bootstrapPeers.isEmpty {
+            host.bootstrap(peers: bootstrapPeers)
+        }
+        host.enableNAT()
+
         isRunning = true
     }
 
-    /// Stops the networking stack and cleans up resources.
+    /// Stops the networking stack and cleans up resources by shutting down the host.
     func stop() {
+        guard isRunning else { return }
+        host?.stop()
+        host = nil
         isRunning = false
     }
 }

--- a/Tests/WeaveTests/P2PNodeTests.swift
+++ b/Tests/WeaveTests/P2PNodeTests.swift
@@ -2,12 +2,39 @@ import XCTest
 @testable import weave
 
 final class P2PNodeTests: XCTestCase {
-    func testStartAndStopToggleRunningState() {
-        let node = P2PNode(bootstrapPeers: ["1.2.3.4:4001"])
+    /// Simple mock host that records whether its lifecycle methods were invoked.
+    final class MockHost: LibP2PHosting {
+        var started = false
+        var bootstrapped: [String] = []
+        var natEnabled = false
+        var stopped = false
+
+        func start() { started = true }
+        func bootstrap(peers: [String]) { bootstrapped = peers }
+        func enableNAT() { natEnabled = true }
+        func stop() { stopped = true }
+    }
+
+    func testStartBootstrapsAndEnablesNAT() {
+        let mock = MockHost()
+        let node = P2PNode(bootstrapPeers: ["1.2.3.4:4001"], hostBuilder: { mock })
+
         XCTAssertFalse(node.isRunning)
         node.start()
+
         XCTAssertTrue(node.isRunning)
+        XCTAssertTrue(mock.started)
+        XCTAssertEqual(mock.bootstrapped, ["1.2.3.4:4001"])
+        XCTAssertTrue(mock.natEnabled)
+    }
+
+    func testStopShutsDownHost() {
+        let mock = MockHost()
+        let node = P2PNode(hostBuilder: { mock })
+        node.start()
         node.stop()
+
         XCTAssertFalse(node.isRunning)
+        XCTAssertTrue(mock.stopped)
     }
 }


### PR DESCRIPTION
## Summary
- add dependency placeholder for Swift libp2p package
- implement P2PNode with pluggable libp2p host and NAT/bootstrap handling
- test P2PNode start/stop using mocked host

## Testing
- `swift test` *(fails: CONNECT tunnel failed, response 403 cloning libp2p)*

------
https://chatgpt.com/codex/tasks/task_e_688faed397d8832b8433361acb81eb78