### PR TITLE
Add CoreLocation-based LocationService

### DIFF
--- a/Sources/LocationService.swift
+++ b/Sources/LocationService.swift
@@ -1,0 +1,55 @@
+#if canImport(CoreLocation)
+import Foundation
+import CoreLocation
+
+/// Delegate protocol to receive location updates.
+protocol LocationServiceDelegate: AnyObject {
+    func locationService(_ service: LocationService, didUpdateLatitude latitude: Double, longitude: Double)
+}
+
+/// A simple wrapper around `CLLocationManager` that requests
+/// permission and forwards coordinate updates to its delegate or
+/// callback.
+final class LocationService: NSObject, CLLocationManagerDelegate {
+    private let manager = CLLocationManager()
+
+    /// Delegate that receives location updates.
+    weak var delegate: LocationServiceDelegate?
+
+    /// Optional closure called when coordinates change.
+    var onLocationUpdate: ((Double, Double) -> Void)?
+
+    override init() {
+        super.init()
+        manager.delegate = self
+    }
+
+    /// Begins requesting authorization and, once granted, updates.
+    func start() {
+        switch manager.authorizationStatus {
+        case .notDetermined:
+            manager.requestWhenInUseAuthorization()
+        case .authorizedWhenInUse, .authorizedAlways:
+            manager.startUpdatingLocation()
+        default:
+            break
+        }
+    }
+
+    // MARK: - CLLocationManagerDelegate
+
+    func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+        if status == .authorizedWhenInUse || status == .authorizedAlways {
+            manager.startUpdatingLocation()
+        }
+    }
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let location = locations.last else { return }
+        let lat = location.coordinate.latitude
+        let lon = location.coordinate.longitude
+        delegate?.locationService(self, didUpdateLatitude: lat, longitude: lon)
+        onLocationUpdate?(lat, lon)
+    }
+}
+#endif

--- a/Tests/WeaveTests/LocationServiceTests.swift
+++ b/Tests/WeaveTests/LocationServiceTests.swift
@@ -1,0 +1,29 @@
+#if canImport(CoreLocation) && os(iOS)
+import XCTest
+import CoreLocation
+@testable import weave
+
+final class LocationServiceTests: XCTestCase {
+    func testLocationUpdatesFeedPeerManager() throws {
+        let expectation = expectation(description: "location update")
+        let service = LocationService()
+        let manager = PeerManager()
+        let peer = try Peer(latitude: 0.0, longitude: 0.0)
+        manager.add(peer)
+
+        service.onLocationUpdate = { lat, lon in
+            manager.updateLocation(id: peer.id, latitude: lat, longitude: lon)
+            expectation.fulfill()
+        }
+
+        // Simulate a location update
+        let simulated = CLLocation(latitude: 50.0, longitude: 8.0)
+        service.locationManager(CLLocationManager(), didUpdateLocations: [simulated])
+
+        waitForExpectations(timeout: 1.0)
+        let updated = manager.peer(id: peer.id)
+        XCTAssertEqual(updated?.latitude, 50.0)
+        XCTAssertEqual(updated?.longitude, 8.0)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Add `LocationService` leveraging `CLLocationManager` to provide location updates via delegate or closure
- Include iOS-only test demonstrating updating `PeerManager` with new coordinates

## Testing
- `swift test` *(fails: unable to clone https://github.com/apple/swift-crypto.git, CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_688faed48cbc832b819a7c418e8d35dd