### PR TITLE
Index peers by geohash prefix

### DIFF
--- a/Sources/PeerManager.swift
+++ b/Sources/PeerManager.swift
@@ -7,7 +7,11 @@ final class PeerManager: @unchecked Sendable {
     private var peerIndex: [UUID: Peer] = [:]
     private var blocked: Set<UUID> = []
     private var liked: Set<UUID> = []
+    /// Maps a geohash prefix to the IDs of peers within that bucket.
+    private var geohashIndex: [String: Set<UUID>] = [:]
     private let queue = DispatchQueue(label: "PeerManager.queue", attributes: .concurrent)
+    /// Length of geohash prefix used for indexing.
+    private let geohashPrefixLength = 5
 
     /// Marks a peer as blocked, excluding it from discovery APIs.
     func block(id: UUID) {
@@ -61,13 +65,27 @@ final class PeerManager: @unchecked Sendable {
     func add(_ peer: Peer) {
         queue.sync(flags: .barrier) {
             peerIndex[peer.id] = peer
+            let prefix = String(peer.geohash.prefix(geohashPrefixLength))
+            var bucket = geohashIndex[prefix] ?? Set<UUID>()
+            bucket.insert(peer.id)
+            geohashIndex[prefix] = bucket
         }
     }
 
     /// Removes a peer by id.
     func remove(id: UUID) {
         queue.sync(flags: .barrier) {
-            peerIndex.removeValue(forKey: id)
+            if let peer = peerIndex.removeValue(forKey: id) {
+                let prefix = String(peer.geohash.prefix(geohashPrefixLength))
+                if var bucket = geohashIndex[prefix] {
+                    bucket.remove(id)
+                    if bucket.isEmpty {
+                        geohashIndex.removeValue(forKey: prefix)
+                    } else {
+                        geohashIndex[prefix] = bucket
+                    }
+                }
+            }
             blocked.remove(id)
             liked.remove(id)
         }
@@ -84,10 +102,25 @@ final class PeerManager: @unchecked Sendable {
     func updateLocation(id: UUID, latitude: Double, longitude: Double) {
         queue.sync(flags: .barrier) {
             guard var peer = peerIndex[id] else { return }
+            let oldPrefix = String(peer.geohash.prefix(geohashPrefixLength))
             peer.latitude = latitude
             peer.longitude = longitude
             peer.lastSeen = Date()
             peerIndex[id] = peer
+            let newPrefix = String(peer.geohash.prefix(geohashPrefixLength))
+            if oldPrefix != newPrefix {
+                if var bucket = geohashIndex[oldPrefix] {
+                    bucket.remove(id)
+                    if bucket.isEmpty {
+                        geohashIndex.removeValue(forKey: oldPrefix)
+                    } else {
+                        geohashIndex[oldPrefix] = bucket
+                    }
+                }
+                var newBucket = geohashIndex[newPrefix] ?? Set<UUID>()
+                newBucket.insert(id)
+                geohashIndex[newPrefix] = newBucket
+            }
         }
     }
 
@@ -187,14 +220,21 @@ final class PeerManager: @unchecked Sendable {
 
 
     /// Returns peers whose geohash begins with the specified prefix. Useful for
-
     /// coarse location-based grouping using geohash bucketing.
     func peers(inGeohash prefix: String) -> [Peer] {
-        queue.sync {
-            peerIndex.values.filter { peer in
-                !blocked.contains(peer.id) && peer.geohash.hasPrefix(prefix)
-            }
+        peers(inGeohash: prefix, matching: [:])
+    }
 
+    /// Returns peers in the specified geohash prefix that match all provided
+    /// attribute filters.
+    func peers(inGeohash prefix: String, matching filters: [String: String]) -> [Peer] {
+        queue.sync {
+            let key = String(prefix.prefix(geohashPrefixLength))
+            guard let ids = geohashIndex[key] else { return [] }
+            return ids.compactMap { id in
+                guard let peer = peerIndex[id], !blocked.contains(id) else { return nil }
+                return filters.allSatisfy { k, v in peer.attributes[k] == v } ? peer : nil
+            }
         }
     }
 
@@ -267,6 +307,9 @@ final class PeerManager: @unchecked Sendable {
         queue.sync(flags: .barrier) {
             peerIndex = peerIndex.filter { $0.value.lastSeen >= cutoff }
             blocked = blocked.filter { peerIndex[$0] != nil }
+            liked = liked.filter { peerIndex[$0] != nil && !blocked.contains($0) }
+            geohashIndex = Dictionary(grouping: peerIndex.values, by: { String($0.geohash.prefix(geohashPrefixLength)) })
+                .mapValues { Set($0.map { $0.id }) }
         }
 
     }
@@ -299,6 +342,8 @@ final class PeerManager: @unchecked Sendable {
             peerIndex = Dictionary(uniqueKeysWithValues: snapshot.peers.map { ($0.id, $0) })
             blocked = Set(snapshot.blocked.filter { peerIndex[$0] != nil })
             liked = Set(snapshot.liked.filter { peerIndex[$0] != nil && !blocked.contains($0) })
+            geohashIndex = Dictionary(grouping: snapshot.peers, by: { String($0.geohash.prefix(geohashPrefixLength)) })
+                .mapValues { Set($0.map { $0.id }) }
         }
     }
 

--- a/Tests/WeaveTests/PeerManagerTests.swift
+++ b/Tests/WeaveTests/PeerManagerTests.swift
@@ -26,8 +26,11 @@ final class PeerManagerTests: XCTestCase {
         let peer = try! Peer(latitude: 37.0, longitude: -122.0)
         manager.add(peer)
         XCTAssertEqual(manager.allPeers().count, 1)
+        let prefix = String(peer.geohash.prefix(5))
+        XCTAssertEqual(manager.peers(inGeohash: prefix), [peer])
         manager.remove(id: peer.id)
         XCTAssertEqual(manager.allPeers().count, 0)
+        XCTAssertTrue(manager.peers(inGeohash: prefix).isEmpty)
     }
 
     func testNearestPeersReturnsSortedResults() {
@@ -116,10 +119,15 @@ final class PeerManagerTests: XCTestCase {
         let manager = PeerManager()
         let peer = try! Peer(latitude: 0.0, longitude: 0.0)
         manager.add(peer)
+        let oldPrefix = String(peer.geohash.prefix(5))
         manager.updateLocation(id: peer.id, latitude: 1.0, longitude: 1.0)
-        let updated = manager.peer(id: peer.id)
-        XCTAssertEqual(updated?.latitude, 1.0)
-        XCTAssertEqual(updated?.longitude, 1.0)
+        let updated = manager.peer(id: peer.id)!
+        XCTAssertEqual(updated.latitude, 1.0)
+        XCTAssertEqual(updated.longitude, 1.0)
+        let newPrefix = String(updated.geohash.prefix(5))
+        XCTAssertNotEqual(oldPrefix, newPrefix)
+        XCTAssertTrue(manager.peers(inGeohash: newPrefix).contains(updated))
+        XCTAssertFalse(manager.peers(inGeohash: oldPrefix).contains(updated))
     }
 
     func testUpdatingPeerAttributes() {


### PR DESCRIPTION
## Summary
- Maintain a geohash bucket index in `PeerManager` for O(1) spatial lookups
- Keep the index in sync when peers are added, removed, or move
- Expose `peers(inGeohash:matching:)` using the index and update tests

## Testing
- `swift test` *(fails: unable to access 'https://github.com/apple/swift-crypto.git')*


------
https://chatgpt.com/codex/tasks/task_e_688faed5221c832b9e87c8a4bf871b6f