### PR TITLE
Add Curve25519 key exchange utilities and integrate with P2PNode

### DIFF
--- a/Sources/Encryption.swift
+++ b/Sources/Encryption.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Crypto
+
+/// Helper utilities for generating key pairs, deriving shared secrets,
+/// and performing symmetric encryption using AES.GCM.
+enum Encryption {
+    struct KeyPair {
+        let privateKey: Curve25519.KeyAgreement.PrivateKey
+        let publicKey: Data
+    }
+
+    /// Generates a Curve25519 key agreement key pair.
+    static func generateKeyPair() -> KeyPair {
+        let privateKey = Curve25519.KeyAgreement.PrivateKey()
+        let publicKey = privateKey.publicKey.rawRepresentation
+        return KeyPair(privateKey: privateKey, publicKey: publicKey)
+    }
+
+    /// Derives a symmetric key using Diffie-Hellman key agreement
+    /// and HKDF-SHA256 key derivation.
+    static func deriveSharedSecret(privateKey: Curve25519.KeyAgreement.PrivateKey,
+                                   peerPublicKey: Data) throws -> SymmetricKey {
+        let peerPub = try Curve25519.KeyAgreement.PublicKey(rawRepresentation: peerPublicKey)
+        let secret = try privateKey.sharedSecretFromKeyAgreement(with: peerPub)
+        return secret.hkdfDerivedSymmetricKey(using: SHA256.self,
+                                              salt: Data(),
+                                              sharedInfo: Data(),
+                                              outputByteCount: 32)
+    }
+
+    /// Encrypts the given plaintext using AES.GCM.
+    static func encrypt(_ plaintext: Data, using key: SymmetricKey) throws -> Data {
+        let sealed = try AES.GCM.seal(plaintext, using: key)
+        guard let combined = sealed.combined else {
+            throw EncryptionError.invalidSealedBox
+        }
+        return combined
+    }
+
+    /// Decrypts ciphertext previously produced by `encrypt`.
+    static func decrypt(_ ciphertext: Data, using key: SymmetricKey) throws -> Data {
+        let box = try AES.GCM.SealedBox(combined: ciphertext)
+        return try AES.GCM.open(box, using: key)
+    }
+
+    enum EncryptionError: Error {
+        case invalidSealedBox
+    }
+}
+

--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Crypto
 
 /// A placeholder networking node that will integrate libp2p in the future.
 /// For now it simply tracks bootstrap peers and whether the node is running.
@@ -8,8 +9,16 @@ final class P2PNode {
     /// Indicates whether the node is actively running.
     private(set) var isRunning: Bool = false
 
+    /// Private key used for Curve25519 key agreement.
+    private let privateKey: Curve25519.KeyAgreement.PrivateKey
+    /// Public key that can be shared with peers.
+    let publicKey: Data
+
     init(bootstrapPeers: [String] = []) {
         self.bootstrapPeers = bootstrapPeers
+        let pair = Encryption.generateKeyPair()
+        self.privateKey = pair.privateKey
+        self.publicKey = pair.publicKey
     }
 
     /// Starts the networking stack. In a real implementation this would
@@ -21,6 +30,31 @@ final class P2PNode {
     /// Stops the networking stack and cleans up resources.
     func stop() {
         isRunning = false
+    }
+
+    /// Encrypts `message` for the given peer using a shared secret.
+    func send(_ message: Data, to peer: Peer) throws -> Data {
+        let key = try sharedKey(with: peer)
+        return try Encryption.encrypt(message, using: key)
+    }
+
+    /// Decrypts data received from the given peer using the shared secret.
+    func receive(_ data: Data, from peer: Peer) throws -> Data {
+        let key = try sharedKey(with: peer)
+        return try Encryption.decrypt(data, using: key)
+    }
+
+    /// Derives a symmetric key from our private key and the peer's public key.
+    private func sharedKey(with peer: Peer) throws -> SymmetricKey {
+        guard let base64 = peer.attributes["publicKey"],
+              let data = Data(base64Encoded: base64) else {
+            throw P2PError.missingPeerPublicKey
+        }
+        return try Encryption.deriveSharedSecret(privateKey: privateKey, peerPublicKey: data)
+    }
+
+    enum P2PError: Error {
+        case missingPeerPublicKey
     }
 }
 

--- a/Tests/WeaveTests/EncryptionTests.swift
+++ b/Tests/WeaveTests/EncryptionTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import weave
+
+final class EncryptionTests: XCTestCase {
+    func testSharedSecretAgreement() throws {
+        let alice = Encryption.generateKeyPair()
+        let bob = Encryption.generateKeyPair()
+        let secret1 = try Encryption.deriveSharedSecret(privateKey: alice.privateKey, peerPublicKey: bob.publicKey)
+        let secret2 = try Encryption.deriveSharedSecret(privateKey: bob.privateKey, peerPublicKey: alice.publicKey)
+        let data1 = secret1.withUnsafeBytes { Data($0) }
+        let data2 = secret2.withUnsafeBytes { Data($0) }
+        XCTAssertEqual(data1, data2)
+    }
+
+    func testEncryptDecryptRoundTrip() throws {
+        let aliceNode = P2PNode()
+        let bobNode = P2PNode()
+
+        let bobPeer = try Peer(id: UUID(), name: "Bob", address: nil, port: nil,
+                               latitude: 0, longitude: 0,
+                               attributes: ["publicKey": bobNode.publicKey.base64EncodedString()])
+        let alicePeer = try Peer(id: UUID(), name: "Alice", address: nil, port: nil,
+                                 latitude: 0, longitude: 0,
+                                 attributes: ["publicKey": aliceNode.publicKey.base64EncodedString()])
+
+        let message = "Hello Bob".data(using: .utf8)!
+        let encrypted = try aliceNode.send(message, to: bobPeer)
+        let decrypted = try bobNode.receive(encrypted, from: alicePeer)
+        XCTAssertEqual(message, decrypted)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `Encryption` helpers for Curve25519 key agreement and AES.GCM encryption
- integrate key generation and encrypted send/receive into `P2PNode`
- test shared secret derivation and encryption round trips

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/apple/swift-crypto.git)*

------
https://chatgpt.com/codex/tasks/task_e_688faed63b18832ba622324ff4546413