### PR TITLE
Include lastSeen in equality checks

### DIFF
--- a/Sources/Peer.swift
+++ b/Sources/Peer.swift
@@ -21,7 +21,9 @@ struct Peer: Identifiable, Codable, Equatable {
 
     /// Arbitrary attributes describing the peer, used for filtering.
     var attributes: [String: String]
-    /// When this peer was last seen or updated.
+    /// When this peer was last seen or updated. This value participates in
+    /// equality checks so that two `Peer` instances representing different
+    /// observation times are treated as distinct states.
     var lastSeen: Date
 
     /// Geohash representation of the peer's location for spatial indexing.
@@ -64,7 +66,8 @@ struct Peer: Identifiable, Codable, Equatable {
         lhs.port == rhs.port &&
         lhs.latitude == rhs.latitude &&
         lhs.longitude == rhs.longitude &&
-        lhs.attributes == rhs.attributes
+        lhs.attributes == rhs.attributes &&
+        lhs.lastSeen == rhs.lastSeen
 
     }
 }

--- a/Tests/WeaveTests/PeerStoreTests.swift
+++ b/Tests/WeaveTests/PeerStoreTests.swift
@@ -5,7 +5,8 @@ final class PeerStoreTests: XCTestCase {
     func testEncryptedSaveLoadRoundTrip() throws {
         let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         let store = PeerStore(url: tempURL)
-        let peer = Peer(latitude: 10.0, longitude: 20.0, attributes: ["foo": "bar"])
+        let timestamp = Date(timeIntervalSince1970: 0)
+        let peer = try Peer(latitude: 10.0, longitude: 20.0, attributes: ["foo": "bar"], lastSeen: timestamp)
         let blocked = [UUID()]
         let liked = [UUID()]
         try store.save(peers: [peer], blocked: blocked, liked: liked)

--- a/Tests/WeaveTests/PeerTests.swift
+++ b/Tests/WeaveTests/PeerTests.swift
@@ -19,4 +19,11 @@ final class PeerTests: XCTestCase {
             }
         }
     }
+
+    func testPeersDifferingByLastSeenAreNotEqual() throws {
+        let baseID = UUID()
+        let first = try Peer(id: baseID, latitude: 0, longitude: 0, lastSeen: Date(timeIntervalSince1970: 0))
+        let second = try Peer(id: baseID, latitude: 0, longitude: 0, lastSeen: Date(timeIntervalSince1970: 10))
+        XCTAssertNotEqual(first, second)
+    }
 }


### PR DESCRIPTION
## Summary
- compare `lastSeen` when checking equality of `Peer`
- fix PeerStore test setup to account for `lastSeen`
- add unit test ensuring differing `lastSeen` values are not equal

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/apple/swift-crypto.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688faed7672c832b9d464b02c9a7194e