### PR TITLE
Inject configurable libp2p host into P2PNode

### DIFF
--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -44,8 +44,10 @@ final class P2PNode {
     /// Public key that can be shared with peers.
     let publicKey: Data
 
-    init(bootstrapPeers: [String] = []) {
+    init(bootstrapPeers: [String] = [],
+         hostBuilder: @escaping () -> LibP2PHosting = { NoopLibP2PHost() }) {
         self.bootstrapPeers = bootstrapPeers
+        self.hostBuilder = hostBuilder
         let pair = Encryption.generateKeyPair()
         self.privateKey = pair.privateKey
         self.publicKey = pair.publicKey


### PR DESCRIPTION
## Summary
- allow injecting a libp2p host via a `hostBuilder` closure
- default to a no-op libp2p host when none is provided

## Testing
- `swift test --filter P2PNodeTests` *(fails: Failed to clone repository https://github.com/libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*
- `swift test --filter EncryptionTests` *(fails: Failed to clone repository https://github.com/libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688fb21ccee0832b8ad2b528deed3a4e