### PR TITLE
Add GeoHash decode and round-trip tests

### DIFF
--- a/Sources/GeoHash.swift
+++ b/Sources/GeoHash.swift
@@ -6,6 +6,13 @@ import Foundation
 /// hash table.
 struct GeoHash {
     private static let base32: [Character] = Array("0123456789bcdefghjkmnpqrstuvwxyz")
+    private static let decodeMap: [Character: Int] = {
+        var map: [Character: Int] = [:]
+        for (index, char) in base32.enumerated() {
+            map[char] = index
+        }
+        return map
+    }()
 
     /// Encodes the given latitude and longitude into a geohash string with the
     /// specified precision (number of characters).
@@ -47,6 +54,41 @@ struct GeoHash {
         }
 
         return String(hash)
+    }
+
+    /// Decodes a geohash string back into a latitude/longitude pair.
+    /// - Parameter hash: The geohash string to decode.
+    /// - Returns: A tuple containing the latitude and longitude at the center of the geohash cell.
+    static func decode(_ hash: String) -> (latitude: Double, longitude: Double) {
+        var latInterval = (-90.0, 90.0)
+        var lonInterval = (-180.0, 180.0)
+        var isEven = true
+
+        for character in hash {
+            guard let value = decodeMap[character] else { continue }
+            for mask in [16, 8, 4, 2, 1] {
+                if isEven {
+                    let mid = (lonInterval.0 + lonInterval.1) / 2
+                    if value & mask != 0 {
+                        lonInterval.0 = mid
+                    } else {
+                        lonInterval.1 = mid
+                    }
+                } else {
+                    let mid = (latInterval.0 + latInterval.1) / 2
+                    if value & mask != 0 {
+                        latInterval.0 = mid
+                    } else {
+                        latInterval.1 = mid
+                    }
+                }
+                isEven.toggle()
+            }
+        }
+
+        let latitude = (latInterval.0 + latInterval.1) / 2
+        let longitude = (lonInterval.0 + lonInterval.1) / 2
+        return (latitude, longitude)
     }
 }
 

--- a/Tests/WeaveTests/GeoHashTests.swift
+++ b/Tests/WeaveTests/GeoHashTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import weave
+
+final class GeoHashTests: XCTestCase {
+    func testEncodeDecodeRoundTrip() {
+        let coordinates: [(Double, Double)] = [
+            (0.0, 0.0),
+            (37.7749, -122.4194),
+            (51.5074, -0.1278)
+        ]
+        let precisions = [4, 8, 12]
+
+        for (lat, lon) in coordinates {
+            for precision in precisions {
+                let hash = GeoHash.encode(latitude: lat, longitude: lon, precision: precision)
+                let (decodedLat, decodedLon) = GeoHash.decode(hash)
+                let (latErr, lonErr) = errorForPrecision(precision)
+                XCTAssertLessThanOrEqual(abs(decodedLat - lat), latErr / 2)
+                XCTAssertLessThanOrEqual(abs(decodedLon - lon), lonErr / 2)
+                let reencoded = GeoHash.encode(latitude: decodedLat, longitude: decodedLon, precision: precision)
+                XCTAssertEqual(reencoded, hash)
+            }
+        }
+    }
+
+    private func errorForPrecision(_ precision: Int) -> (Double, Double) {
+        var latBits = 0
+        var lonBits = 0
+        for i in 0..<(precision * 5) {
+            if i % 2 == 0 { lonBits += 1 } else { latBits += 1 }
+        }
+        let latErr = 180.0 / Double(1 << latBits)
+        let lonErr = 360.0 / Double(1 << lonBits)
+        return (latErr, lonErr)
+    }
+}


### PR DESCRIPTION
## Summary
- implement geohash decode using bit interleaving
- add round-trip encode/decode tests

## Testing
- `swift test` *(fails: CONNECT tunnel failed when cloning swift-libp2p)*

------
https://chatgpt.com/codex/tasks/task_e_688fb21dc928832b8690bda8180e7b1b