### PR TITLE
Handle CLLocation errors in LocationService

### DIFF
--- a/Sources/LocationService.swift
+++ b/Sources/LocationService.swift
@@ -2,9 +2,10 @@
 import Foundation
 import CoreLocation
 
-/// Delegate protocol to receive location updates.
+/// Delegate protocol to receive location updates and errors.
 protocol LocationServiceDelegate: AnyObject {
     func locationService(_ service: LocationService, didUpdateLatitude latitude: Double, longitude: Double)
+    func locationService(_ service: LocationService, didFailWithError error: Error)
 }
 
 /// A simple wrapper around `CLLocationManager` that requests
@@ -18,6 +19,9 @@ final class LocationService: NSObject, CLLocationManagerDelegate {
 
     /// Optional closure called when coordinates change.
     var onLocationUpdate: ((Double, Double) -> Void)?
+
+    /// Optional closure called when errors occur.
+    var onError: ((Error) -> Void)?
 
     override init() {
         super.init()
@@ -50,6 +54,11 @@ final class LocationService: NSObject, CLLocationManagerDelegate {
         let lon = location.coordinate.longitude
         delegate?.locationService(self, didUpdateLatitude: lat, longitude: lon)
         onLocationUpdate?(lat, lon)
+    }
+
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        delegate?.locationService(self, didFailWithError: error)
+        onError?(error)
     }
 }
 #endif

--- a/Tests/WeaveTests/LocationServiceTests.swift
+++ b/Tests/WeaveTests/LocationServiceTests.swift
@@ -1,4 +1,4 @@
-#if canImport(CoreLocation) && os(iOS)
+#if canImport(CoreLocation)
 import XCTest
 import CoreLocation
 @testable import weave
@@ -24,6 +24,33 @@ final class LocationServiceTests: XCTestCase {
         let updated = manager.peer(id: peer.id)
         XCTAssertEqual(updated?.latitude, 50.0)
         XCTAssertEqual(updated?.longitude, 8.0)
+    }
+
+    func testErrorPropagation() {
+        let delegateExpectation = expectation(description: "delegate error")
+        let closureExpectation = expectation(description: "closure error")
+        let service = LocationService()
+
+        class Delegate: LocationServiceDelegate {
+            var expectation: XCTestExpectation?
+
+            func locationService(_ service: LocationService, didUpdateLatitude latitude: Double, longitude: Double) {}
+
+            func locationService(_ service: LocationService, didFailWithError error: Error) {
+                expectation?.fulfill()
+            }
+        }
+
+        let delegate = Delegate()
+        delegate.expectation = delegateExpectation
+        service.delegate = delegate
+
+        service.onError = { _ in closureExpectation.fulfill() }
+
+        let error = NSError(domain: "test", code: 1)
+        service.locationManager(CLLocationManager(), didFailWithError: error)
+
+        wait(for: [delegateExpectation, closureExpectation], timeout: 1.0)
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- Extend `LocationServiceDelegate` with error callback and add `onError` closure
- Forward `CLLocationManager` errors to delegates and closure
- Add unit test simulating location manager error propagation

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/libp2p/swift-libp2p.git, CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_688fb21ea54c832b8fd132690763b08c