### PR TITLE
Add explicit publicKey to Peer and use it in P2PNode

### DIFF
--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -93,11 +93,10 @@ final class P2PNode {
 
     /// Derives a symmetric key from our private key and the peer's public key.
     private func sharedKey(with peer: Peer) throws -> SymmetricKey {
-        guard let base64 = peer.attributes["publicKey"],
-              let data = Data(base64Encoded: base64) else {
+        guard let publicKey = peer.publicKey else {
             throw P2PError.missingPeerPublicKey
         }
-        return try Encryption.deriveSharedSecret(privateKey: privateKey, peerPublicKey: data)
+        return try Encryption.deriveSharedSecret(privateKey: privateKey, peerPublicKey: publicKey)
     }
 
     enum P2PError: Error {

--- a/Sources/Peer.swift
+++ b/Sources/Peer.swift
@@ -16,6 +16,8 @@ struct Peer: Identifiable, Codable, Equatable {
 
     var address: String?
     var port: UInt16?
+    /// Public key advertised by the peer for encrypted communication.
+    var publicKey: Data?
     var latitude: Double
     var longitude: Double
 
@@ -31,11 +33,16 @@ struct Peer: Identifiable, Codable, Equatable {
         GeoHash.encode(latitude: latitude, longitude: longitude)
     }
 
+    enum CodingKeys: String, CodingKey {
+        case id, name, address, port, publicKey, latitude, longitude, attributes, lastSeen
+    }
+
     init(id: UUID = UUID(),
          name: String? = nil,
 
          address: String? = nil,
          port: UInt16? = nil,
+         publicKey: Data? = nil,
          latitude: Double,
          longitude: Double,
 
@@ -53,10 +60,46 @@ struct Peer: Identifiable, Codable, Equatable {
 
         self.address = address
         self.port = port
+        self.publicKey = publicKey
         self.latitude = latitude
         self.longitude = longitude
         self.attributes = attributes
         self.lastSeen = lastSeen
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let id = try container.decode(UUID.self, forKey: .id)
+        let name = try container.decodeIfPresent(String.self, forKey: .name)
+        let address = try container.decodeIfPresent(String.self, forKey: .address)
+        let port = try container.decodeIfPresent(UInt16.self, forKey: .port)
+        let publicKey = try container.decodeIfPresent(Data.self, forKey: .publicKey)
+        let latitude = try container.decode(Double.self, forKey: .latitude)
+        let longitude = try container.decode(Double.self, forKey: .longitude)
+        let attributes = try container.decode([String: String].self, forKey: .attributes)
+        let lastSeen = try container.decode(Date.self, forKey: .lastSeen)
+        try self.init(id: id,
+                      name: name,
+                      address: address,
+                      port: port,
+                      publicKey: publicKey,
+                      latitude: latitude,
+                      longitude: longitude,
+                      attributes: attributes,
+                      lastSeen: lastSeen)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encodeIfPresent(name, forKey: .name)
+        try container.encodeIfPresent(address, forKey: .address)
+        try container.encodeIfPresent(port, forKey: .port)
+        try container.encodeIfPresent(publicKey, forKey: .publicKey)
+        try container.encode(latitude, forKey: .latitude)
+        try container.encode(longitude, forKey: .longitude)
+        try container.encode(attributes, forKey: .attributes)
+        try container.encode(lastSeen, forKey: .lastSeen)
     }
 
     static func == (lhs: Peer, rhs: Peer) -> Bool {
@@ -64,6 +107,7 @@ struct Peer: Identifiable, Codable, Equatable {
         lhs.name == rhs.name &&
         lhs.address == rhs.address &&
         lhs.port == rhs.port &&
+        lhs.publicKey == rhs.publicKey &&
         lhs.latitude == rhs.latitude &&
         lhs.longitude == rhs.longitude &&
         lhs.attributes == rhs.attributes &&

--- a/Tests/WeaveTests/EncryptionTests.swift
+++ b/Tests/WeaveTests/EncryptionTests.swift
@@ -17,11 +17,11 @@ final class EncryptionTests: XCTestCase {
         let bobNode = P2PNode()
 
         let bobPeer = try Peer(id: UUID(), name: "Bob", address: nil, port: nil,
-                               latitude: 0, longitude: 0,
-                               attributes: ["publicKey": bobNode.publicKey.base64EncodedString()])
+                               publicKey: bobNode.publicKey,
+                               latitude: 0, longitude: 0)
         let alicePeer = try Peer(id: UUID(), name: "Alice", address: nil, port: nil,
-                                 latitude: 0, longitude: 0,
-                                 attributes: ["publicKey": aliceNode.publicKey.base64EncodedString()])
+                                 publicKey: aliceNode.publicKey,
+                                 latitude: 0, longitude: 0)
 
         let message = "Hello Bob".data(using: .utf8)!
         let encrypted = try aliceNode.send(message, to: bobPeer)

--- a/Tests/WeaveTests/P2PNodeTests.swift
+++ b/Tests/WeaveTests/P2PNodeTests.swift
@@ -47,4 +47,14 @@ final class P2PNodeTests: XCTestCase {
             XCTAssertEqual(error as? P2PNode.P2PError, .missingPeerPublicKey)
         }
     }
+
+    func testReceiveThrowsWhenPeerLacksPublicKey() throws {
+        let node = P2PNode()
+        let peer = try Peer(latitude: 0, longitude: 0)
+        let data = Data("hi".utf8)
+
+        XCTAssertThrowsError(try node.receive(data, from: peer)) { error in
+            XCTAssertEqual(error as? P2PNode.P2PError, .missingPeerPublicKey)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add optional `publicKey` field to `Peer` with full Codable support
- use `peer.publicKey` in `P2PNode` shared key derivation
- update tests and add coverage for missing peer public key errors

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688fb4683b54832bbb5cbbafbe91ed74