### PR TITLE
Synchronize nearestPeers and add concurrency test

### DIFF
--- a/Sources/PeerManager.swift
+++ b/Sources/PeerManager.swift
@@ -247,21 +247,21 @@ final class PeerManager: @unchecked Sendable {
                       longitude: Double,
                       limit: Int,
                       matching filters: [String: String] = [:]) -> [Peer] {
+        queue.sync {
+            let candidates = peerIndex.values
+                .filter { peer in
+                    !blocked.contains(peer.id) &&
+                    filters.allSatisfy { key, value in peer.attributes[key] == value }
+                }
+                .map { peer -> (peer: Peer, distance: Double) in
+                    let dist = distance(from: (latitude, longitude),
+                                        to: (peer.latitude, peer.longitude))
+                    return (peer, dist)
+                }
+                .sorted { $0.distance < $1.distance }
 
-        let candidates = peerIndex.values
-            .filter { peer in
-                !blocked.contains(peer.id) &&
-                filters.allSatisfy { key, value in peer.attributes[key] == value }
-            }
-            .map { peer -> (peer: Peer, distance: Double) in
-                let dist = distance(from: (latitude, longitude),
-                                    to: (peer.latitude, peer.longitude))
-                return (peer, dist)
-            }
-            .sorted { $0.distance < $1.distance }
-
-        return candidates.prefix(limit).map { $0.peer }
-
+            return candidates.prefix(limit).map { $0.peer }
+        }
     }
 
     /// Returns up to `limit` most recently seen peers, excluding any that are blocked.

--- a/Tests/WeaveTests/PeerManagerTests.swift
+++ b/Tests/WeaveTests/PeerManagerTests.swift
@@ -418,4 +418,31 @@ final class PeerManagerTests: XCTestCase {
         group.wait()
         XCTAssertEqual(manager.allPeers().count, 100)
     }
+
+    /// Invokes `nearestPeers` while other threads mutate the manager to ensure thread safety.
+    func testNearestPeersThreadSafetyDuringMutation() {
+        let manager = PeerManager()
+        let queue = DispatchQueue.global(qos: .default)
+        let group = DispatchGroup()
+
+        for _ in 0..<100 {
+            group.enter()
+            queue.async {
+                let peer = try! Peer(latitude: 0.0, longitude: 0.0)
+                manager.add(peer)
+                group.leave()
+            }
+
+            group.enter()
+            queue.async {
+                _ = manager.nearestPeers(to: 0.0, longitude: 0.0, limit: 5)
+                group.leave()
+            }
+        }
+
+        group.wait()
+
+        XCTAssertEqual(manager.allPeers().count, 100)
+        XCTAssertLessThanOrEqual(manager.nearestPeers(to: 0.0, longitude: 0.0, limit: 5).count, 5)
+    }
 }


### PR DESCRIPTION
## Summary
- synchronize `nearestPeers` with `queue.sync` to safely access `peerIndex` and `blocked`
- add a concurrent test calling `nearestPeers` while peers are added

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688fb4679dd8832bb92a5259413381b7