### PR TITLE
Use file-based key storage for PeerStore

### DIFF
--- a/Sources/PeerStore.swift
+++ b/Sources/PeerStore.swift
@@ -8,8 +8,8 @@ import Crypto
 import Security
 #else
 // On platforms without the Security framework (e.g. Linux), declare a
-// compatible alias so the code can compile. The key is stored using
-// `UserDefaults` in this case which is not as secure but keeps tests running.
+// compatible alias so the code can compile. The key is stored in a file with
+// restrictive permissions instead of the Keychain.
 typealias OSStatus = Int32
 #endif
 
@@ -56,8 +56,8 @@ struct PeerStore {
     private static let keyTag = "com.weave.peerstorekey"
 
     /// Retrieves an existing encryption key or creates one if needed. On Apple
-    /// platforms the key is stored in the Keychain; elsewhere a less secure
-    /// `UserDefaults` storage is used for testing purposes.
+    /// platforms the key is stored in the Keychain; elsewhere it is stored in a
+    /// file with restrictive permissions.
     private func loadOrCreateKey() throws -> SymmetricKey {
 #if canImport(Security)
         let query: [String: Any] = [
@@ -89,16 +89,35 @@ struct PeerStore {
         }
         return key
 #else
-        let defaults = UserDefaults.standard
-        if let data = defaults.data(forKey: Self.keyTag) {
+        if let data = Self.readKeyFile(at: keyURL) {
             return SymmetricKey(data: data)
         }
         let key = SymmetricKey(size: .bits256)
         let data = key.withUnsafeBytes { Data($0) }
-        defaults.set(data, forKey: Self.keyTag)
+        try Self.writeKeyFile(data, to: keyURL)
         return key
 #endif
     }
+
+#if !canImport(Security)
+    /// URL of the key file used on platforms without Keychain access.
+    private var keyURL: URL {
+        url.deletingLastPathComponent().appendingPathComponent("\(Self.keyTag).key")
+    }
+
+    /// Atomically reads the key file if it exists.
+    static func readKeyFile(at url: URL) -> Data? {
+        try? Data(contentsOf: url)
+    }
+
+    /// Atomically writes the key file with restrictive permissions.
+    static func writeKeyFile(_ data: Data, to url: URL) throws {
+        let fm = FileManager.default
+        try fm.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try data.write(to: url, options: .atomic)
+        try fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+    }
+#endif
 
     /// Saves the provided peers and blocked/liked IDs to disk, overwriting any
     /// existing file. Data is encrypted using AES.GCM before being written.

--- a/Tests/WeaveTests/PeerStoreTests.swift
+++ b/Tests/WeaveTests/PeerStoreTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Foundation
 @testable import weave
 
 final class PeerStoreTests: XCTestCase {
@@ -17,5 +18,28 @@ final class PeerStoreTests: XCTestCase {
 
         let data = try Data(contentsOf: tempURL)
         XCTAssertThrowsError(try JSONDecoder().decode([Peer].self, from: data))
+    }
+
+    func testKeyFilePersistsAcrossInstances() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let storeURL = tempDir.appendingPathComponent("store.json")
+
+        let peer = try Peer(latitude: 0.0, longitude: 0.0)
+        let store = PeerStore(url: storeURL)
+        try store.save(peers: [peer], blocked: [])
+
+        let keyURL = tempDir.appendingPathComponent("com.weave.peerstorekey.key")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: keyURL.path))
+
+        // Create a new store instance and ensure the previous data can be read.
+        let secondStore = PeerStore(url: storeURL)
+        let loaded = try secondStore.load().peers
+        XCTAssertEqual(loaded, [peer])
+
+        // Verify restrictive permissions (0o600)
+        let attrs = try FileManager.default.attributesOfItem(atPath: keyURL.path)
+        let perms = attrs[.posixPermissions] as? Int
+        XCTAssertEqual(perms, 0o600)
     }
 }


### PR DESCRIPTION
## Summary
- Replace UserDefaults key storage with file-based storage on platforms without Keychain
- Add atomic helper functions to manage the key file with restrictive permissions
- Extend tests to ensure the key file persists across instances and has tight permissions

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688fb4690a3c832b9a5ba7b4841d9b2c