### PR TITLE
Handle invalid characters in GeoHash decoding

### DIFF
--- a/Sources/GeoHash.swift
+++ b/Sources/GeoHash.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+enum GeoHashError: Error {
+    case invalidCharacter(Character)
+}
+
 /// Utility for encoding geographic coordinates into a geohash string.
 /// Geohashes compactly represent latitude/longitude pairs and can be used
 /// for coarse spatial grouping, e.g. when indexing peers in a distributed
@@ -59,13 +63,15 @@ struct GeoHash {
     /// Decodes a geohash string back into a latitude/longitude pair.
     /// - Parameter hash: The geohash string to decode.
     /// - Returns: A tuple containing the latitude and longitude at the center of the geohash cell.
-    static func decode(_ hash: String) -> (latitude: Double, longitude: Double) {
+    static func decode(_ hash: String) throws -> (latitude: Double, longitude: Double) {
         var latInterval = (-90.0, 90.0)
         var lonInterval = (-180.0, 180.0)
         var isEven = true
 
         for character in hash {
-            guard let value = decodeMap[character] else { continue }
+            guard let value = decodeMap[character] else {
+                throw GeoHashError.invalidCharacter(character)
+            }
             for mask in [16, 8, 4, 2, 1] {
                 if isEven {
                     let mid = (lonInterval.0 + lonInterval.1) / 2

--- a/Tests/WeaveTests/GeoHashTests.swift
+++ b/Tests/WeaveTests/GeoHashTests.swift
@@ -13,13 +13,26 @@ final class GeoHashTests: XCTestCase {
         for (lat, lon) in coordinates {
             for precision in precisions {
                 let hash = GeoHash.encode(latitude: lat, longitude: lon, precision: precision)
-                let (decodedLat, decodedLon) = GeoHash.decode(hash)
-                let (latErr, lonErr) = errorForPrecision(precision)
-                XCTAssertLessThanOrEqual(abs(decodedLat - lat), latErr / 2)
-                XCTAssertLessThanOrEqual(abs(decodedLon - lon), lonErr / 2)
-                let reencoded = GeoHash.encode(latitude: decodedLat, longitude: decodedLon, precision: precision)
-                XCTAssertEqual(reencoded, hash)
+                do {
+                    let (decodedLat, decodedLon) = try GeoHash.decode(hash)
+                    let (latErr, lonErr) = errorForPrecision(precision)
+                    XCTAssertLessThanOrEqual(abs(decodedLat - lat), latErr / 2)
+                    XCTAssertLessThanOrEqual(abs(decodedLon - lon), lonErr / 2)
+                    let reencoded = GeoHash.encode(latitude: decodedLat, longitude: decodedLon, precision: precision)
+                    XCTAssertEqual(reencoded, hash)
+                } catch {
+                    XCTFail("Unexpected error: \(error)")
+                }
             }
+        }
+    }
+
+    func testDecodeInvalidCharacterThrows() {
+        XCTAssertThrowsError(try GeoHash.decode("invalid!hash")) { error in
+            guard case GeoHashError.invalidCharacter(let char) = error else {
+                return XCTFail("Expected invalidCharacter error")
+            }
+            XCTAssertEqual(char, "!")
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `GeoHashError` for invalid characters
- Make `GeoHash.decode` throw on unknown characters
- Update tests to handle errors and check invalid input

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/libp2p/swift-libp2p.git)*

------
https://chatgpt.com/codex/tasks/task_e_688fbb2fe7a8832b8c0fd9faca5eda4b