### PR TITLE
Validate geohash precision

### DIFF
--- a/Sources/GeoHash.swift
+++ b/Sources/GeoHash.swift
@@ -17,6 +17,8 @@ struct GeoHash {
     /// Encodes the given latitude and longitude into a geohash string with the
     /// specified precision (number of characters).
     static func encode(latitude: Double, longitude: Double, precision: Int = 8) -> String {
+        guard (1...12).contains(precision) else { return "" }
+
         var latInterval = (-90.0, 90.0)
         var lonInterval = (-180.0, 180.0)
         var isEven = true

--- a/Tests/WeaveTests/GeoHashTests.swift
+++ b/Tests/WeaveTests/GeoHashTests.swift
@@ -23,6 +23,11 @@ final class GeoHashTests: XCTestCase {
         }
     }
 
+    func testInvalidPrecisionReturnsEmptyString() {
+        XCTAssertEqual(GeoHash.encode(latitude: 0, longitude: 0, precision: 0), "")
+        XCTAssertEqual(GeoHash.encode(latitude: 0, longitude: 0, precision: 13), "")
+    }
+
     private func errorForPrecision(_ precision: Int) -> (Double, Double) {
         var latBits = 0
         var lonBits = 0


### PR DESCRIPTION
## Summary
- Guard GeoHash encode precision to 1-12 and return empty string on invalid value
- Add tests ensuring invalid precision is rejected

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688fbb3096e8832b8beb428570a05d51