### PR TITLE
Add actor isolation to P2PNode

### DIFF
--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -28,11 +28,11 @@ struct NoopLibP2PHost: LibP2PHosting {
 /// A networking node backed by a libp2p host.
 /// The node is initialised with a list of bootstrap peers and is responsible
 /// for starting and stopping the underlying host.
-final class P2PNode {
+actor P2PNode {
     /// Addresses of peers used to join the wider network.
     private let bootstrapPeers: [String]
     /// Factory used to create the libp2p host. Injected to allow mocking in tests.
-    private let hostBuilder: () -> LibP2PHosting
+    private let hostBuilder: @Sendable () -> LibP2PHosting
     /// The underlying libp2p host instance once started.
     private var host: LibP2PHosting?
     /// Indicates whether the node is actively running.
@@ -45,7 +45,7 @@ final class P2PNode {
     let publicKey: Data
 
     init(bootstrapPeers: [String] = [],
-         hostBuilder: @escaping () -> LibP2PHosting = { NoopLibP2PHost() }) {
+         hostBuilder: @escaping @Sendable () -> LibP2PHosting = { NoopLibP2PHost() }) {
         self.bootstrapPeers = bootstrapPeers
         self.hostBuilder = hostBuilder
         let pair = Encryption.generateKeyPair()

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -1,113 +1,116 @@
 import Foundation
 
+@main
+struct Main {
+    static func main() async {
+        // Demonstration of using the PeerManager alongside a placeholder
+        // networking node that will eventually speak libp2p.
+        let node = P2PNode(bootstrapPeers: ["bootstrap.weave.example:4001"])
+        await node.start()
 
-// Demonstration of using the PeerManager alongside a placeholder
-// networking node that will eventually speak libp2p.
-let node = P2PNode(bootstrapPeers: ["bootstrap.weave.example:4001"])
-node.start()
-defer { node.stop() }
+        let manager = PeerManager()
 
-let manager = PeerManager()
+        // Assume the current user is in San Francisco
+        let selfLat = 37.7749
+        let selfLon = -122.4194
 
-// Assume the current user is in San Francisco
-let selfLat = 37.7749
-let selfLon = -122.4194
+        let me = try! Peer(name: "Me", latitude: selfLat, longitude: selfLon, attributes: ["hobby": "hiking"])
 
-let me = try! Peer(name: "Me", latitude: selfLat, longitude: selfLon, attributes: ["hobby": "hiking"])
+        // Add a peer in San Francisco
+        let movingPeer = try! Peer(name: "Alice", latitude: 37.7750, longitude: -122.4183, attributes: ["hobby": "hiking", "likes": me.id.uuidString])
+        manager.add(movingPeer)
 
+        // Add another peer in Los Angeles with the same hobby
+        let laPeer = try! Peer(name: "Bob", latitude: 34.0522, longitude: -118.2437, attributes: ["hobby": "hiking"])
 
-// Add a peer in San Francisco
-let movingPeer = try! Peer(name: "Alice", latitude: 37.7750, longitude: -122.4183, attributes: ["hobby": "hiking", "likes": me.id.uuidString])
-manager.add(movingPeer)
+        manager.add(laPeer)
 
-// Add another peer in Los Angeles with the same hobby
-let laPeer = try! Peer(name: "Bob", latitude: 34.0522, longitude: -118.2437, attributes: ["hobby": "hiking"])
+        // Query peers sharing the same geohash prefix as the moving peer (coarse area
+        // match) and demonstrate attribute filtering.
+        let prefix = String(movingPeer.geohash.prefix(5))
+        let geohashPeers = manager.peers(inGeohash: prefix)
+        print("Peers in geohash prefix \(prefix): \(geohashPeers.count)")
+        let hikingInPrefix = manager.peers(inGeohash: prefix, matching: ["hobby": "hiking"])
+        print("Hiking peers in geohash prefix \(prefix): \(hikingInPrefix.count)")
 
-manager.add(laPeer)
+        var nearbyPeers = manager.peers(near: selfLat, longitude: selfLon, radius: 5000.0)
+        print("Peers within 5000km: \(nearbyPeers.count)")
 
-// Query peers sharing the same geohash prefix as the moving peer (coarse area
-// match) and demonstrate attribute filtering.
-let prefix = String(movingPeer.geohash.prefix(5))
-let geohashPeers = manager.peers(inGeohash: prefix)
-print("Peers in geohash prefix \(prefix): \(geohashPeers.count)")
-let hikingInPrefix = manager.peers(inGeohash: prefix, matching: ["hobby": "hiking"])
-print("Hiking peers in geohash prefix \(prefix): \(hikingInPrefix.count)")
+        // Connect to the moving peer and refresh its last-seen timestamp
+        if manager.connect(to: movingPeer.id) {
+            print("Connected to moving peer")
+        }
 
+        // Like and then unlike the moving peer
+        manager.like(id: movingPeer.id)
+        print("Liked peers: \(manager.likedPeers().count)")
+        manager.unlike(id: movingPeer.id)
+        print("Liked peers after unlike: \(manager.likedPeers().count)")
+        // Like again to demonstrate mutual match detection
+        manager.like(id: movingPeer.id)
+        let mutual = manager.mutualLikes(for: me.id)
+        print("Mutual matches: \(mutual.count)")
 
-var nearbyPeers = manager.peers(near: selfLat, longitude: selfLon, radius: 5000.0)
-print("Peers within 5000km: \(nearbyPeers.count)")
+        // Block the Los Angeles peer
+        manager.block(id: laPeer.id)
+        nearbyPeers = manager.peers(near: selfLat, longitude: selfLon, radius: 5000.0)
+        print("Peers after blocking LA user: \(nearbyPeers.count)")
 
-// Connect to the moving peer and refresh its last-seen timestamp
-if manager.connect(to: movingPeer.id) {
-    print("Connected to moving peer")
+        // Update the peer's location to New York
+        manager.updateLocation(id: movingPeer.id, latitude: 40.7128, longitude: -74.0060)
+        nearbyPeers = manager.peers(near: selfLat, longitude: selfLon, radius: 5.0)
+        print("Nearby peers after move: \(nearbyPeers.count)")
+
+        // Update the peer's network address
+        manager.updateAddress(id: movingPeer.id, address: "203.0.113.1", port: 8080)
+        if let updated = manager.peer(id: movingPeer.id) {
+            print("Peer network address: \(updated.address ?? "n/a"):\(updated.port ?? 0)")
+        }
+
+        // Change the peer's display name
+        manager.updateName(id: movingPeer.id, name: "Traveler")
+        print("Peer name after update: \(manager.peer(id: movingPeer.id)?.name ?? "none")")
+
+        // Update a single attribute and then remove it
+        manager.updateAttribute(id: movingPeer.id, key: "hobby", value: "climbing")
+        print("Updated hobby: \(manager.peer(id: movingPeer.id)?.attributes["hobby"] ?? "none")")
+        manager.removeAttribute(id: movingPeer.id, key: "hobby")
+        print("Hobby after removal: \(manager.peer(id: movingPeer.id)?.attributes["hobby"] ?? "none")")
+
+        let hikers = manager.peers(near: selfLat, longitude: selfLon, radius: 5000.0, matching: ["hobby": "hiking"])
+        print("Hikers within 5000km: \(hikers.count)")
+
+        let matches = manager.matchPeers(for: me, radius: 5000.0, limit: 5)
+        print("Top matches by hobby within 5000km: \(matches.count)")
+
+        let nearestHikers = manager.nearestPeers(to: selfLat,
+                                                 longitude: selfLon,
+                                                 limit: 3,
+                                                 matching: ["hobby": "hiking"])
+        print("Nearest hikers: \(nearestHikers.count)")
+
+        // Persist peers to disk and load them back
+        let storeURL = URL(fileURLWithPath: "/tmp/peers.json")
+        let store = PeerStore(url: storeURL)
+        try? manager.save(to: store)
+        let restored = PeerManager()
+        try? restored.load(from: store)
+        print("Restored \(restored.allPeers().count) peer(s) from disk (blocked peers excluded)")
+        restored.unblock(id: laPeer.id)
+        print("After unblocking LA user post-restore: \(restored.allPeers().count) peer(s)")
+
+        // Demonstrate pruning stale peers
+        let stalePeer = try! Peer(latitude: 35.0, longitude: -120.0, lastSeen: Date(timeIntervalSinceNow: -7200))
+        manager.add(stalePeer)
+        print("Total peers before pruning: \(manager.allPeers().count)")
+        manager.pruneStale(before: Date(timeIntervalSinceNow: -3600))
+        print("Peers after pruning stale entries: \(manager.allPeers().count)")
+
+        // Fetch the most recently seen peers
+        let recent = manager.recentPeers(limit: 2)
+        print("Most recently seen peers: \(recent.count)")
+
+        await node.stop()
+    }
 }
-
-// Like and then unlike the moving peer
-manager.like(id: movingPeer.id)
-print("Liked peers: \(manager.likedPeers().count)")
-manager.unlike(id: movingPeer.id)
-print("Liked peers after unlike: \(manager.likedPeers().count)")
-// Like again to demonstrate mutual match detection
-manager.like(id: movingPeer.id)
-let mutual = manager.mutualLikes(for: me.id)
-print("Mutual matches: \(mutual.count)")
-
-// Block the Los Angeles peer
-manager.block(id: laPeer.id)
-nearbyPeers = manager.peers(near: selfLat, longitude: selfLon, radius: 5000.0)
-print("Peers after blocking LA user: \(nearbyPeers.count)")
-
-// Update the peer's location to New York
-manager.updateLocation(id: movingPeer.id, latitude: 40.7128, longitude: -74.0060)
-nearbyPeers = manager.peers(near: selfLat, longitude: selfLon, radius: 5.0)
-print("Nearby peers after move: \(nearbyPeers.count)")
-
-// Update the peer's network address
-manager.updateAddress(id: movingPeer.id, address: "203.0.113.1", port: 8080)
-if let updated = manager.peer(id: movingPeer.id) {
-    print("Peer network address: \(updated.address ?? "n/a"):\(updated.port ?? 0)")
-}
-
-// Change the peer's display name
-manager.updateName(id: movingPeer.id, name: "Traveler")
-print("Peer name after update: \(manager.peer(id: movingPeer.id)?.name ?? "none")")
-
-// Update a single attribute and then remove it
-manager.updateAttribute(id: movingPeer.id, key: "hobby", value: "climbing")
-print("Updated hobby: \(manager.peer(id: movingPeer.id)?.attributes["hobby"] ?? "none")")
-manager.removeAttribute(id: movingPeer.id, key: "hobby")
-print("Hobby after removal: \(manager.peer(id: movingPeer.id)?.attributes["hobby"] ?? "none")")
-
-let hikers = manager.peers(near: selfLat, longitude: selfLon, radius: 5000.0, matching: ["hobby": "hiking"])
-print("Hikers within 5000km: \(hikers.count)")
-
-let matches = manager.matchPeers(for: me, radius: 5000.0, limit: 5)
-print("Top matches by hobby within 5000km: \(matches.count)")
-
-let nearestHikers = manager.nearestPeers(to: selfLat,
-                                         longitude: selfLon,
-                                         limit: 3,
-                                         matching: ["hobby": "hiking"])
-print("Nearest hikers: \(nearestHikers.count)")
-
-// Persist peers to disk and load them back
-let storeURL = URL(fileURLWithPath: "/tmp/peers.json")
-let store = PeerStore(url: storeURL)
-try? manager.save(to: store)
-let restored = PeerManager()
-try? restored.load(from: store)
-print("Restored \(restored.allPeers().count) peer(s) from disk (blocked peers excluded)")
-restored.unblock(id: laPeer.id)
-print("After unblocking LA user post-restore: \(restored.allPeers().count) peer(s)")
-
-// Demonstrate pruning stale peers
-let stalePeer = try! Peer(latitude: 35.0, longitude: -120.0, lastSeen: Date(timeIntervalSinceNow: -7200))
-manager.add(stalePeer)
-print("Total peers before pruning: \(manager.allPeers().count)")
-manager.pruneStale(before: Date(timeIntervalSinceNow: -3600))
-print("Peers after pruning stale entries: \(manager.allPeers().count)")
-
-// Fetch the most recently seen peers
-let recent = manager.recentPeers(limit: 2)
-print("Most recently seen peers: \(recent.count)")
 

--- a/Tests/WeaveTests/EncryptionTests.swift
+++ b/Tests/WeaveTests/EncryptionTests.swift
@@ -12,7 +12,7 @@ final class EncryptionTests: XCTestCase {
         XCTAssertEqual(data1, data2)
     }
 
-    func testEncryptDecryptRoundTrip() throws {
+    func testEncryptDecryptRoundTrip() async throws {
         let aliceNode = P2PNode()
         let bobNode = P2PNode()
 
@@ -24,8 +24,8 @@ final class EncryptionTests: XCTestCase {
                                  latitude: 0, longitude: 0)
 
         let message = "Hello Bob".data(using: .utf8)!
-        let encrypted = try aliceNode.send(message, to: bobPeer)
-        let decrypted = try bobNode.receive(encrypted, from: alicePeer)
+        let encrypted = try await aliceNode.send(message, to: bobPeer)
+        let decrypted = try await bobNode.receive(encrypted, from: alicePeer)
         XCTAssertEqual(message, decrypted)
     }
 }

--- a/Tests/WeaveTests/P2PNodeTests.swift
+++ b/Tests/WeaveTests/P2PNodeTests.swift
@@ -4,57 +4,84 @@ import XCTest
 final class P2PNodeTests: XCTestCase {
     /// Simple mock host that records whether its lifecycle methods were invoked.
     final class MockHost: LibP2PHosting {
-        var started = false
+        var startCount = 0
         var bootstrapped: [String] = []
         var natEnabled = false
-        var stopped = false
+        var stopCount = 0
 
-        func start() { started = true }
+        func start() { startCount += 1 }
         func bootstrap(peers: [String]) { bootstrapped = peers }
         func enableNAT() { natEnabled = true }
-        func stop() { stopped = true }
+        func stop() { stopCount += 1 }
     }
 
-    func testStartBootstrapsAndEnablesNAT() {
+    func testStartBootstrapsAndEnablesNAT() async {
         let mock = MockHost()
         let node = P2PNode(bootstrapPeers: ["1.2.3.4:4001"], hostBuilder: { mock })
 
-        XCTAssertFalse(node.isRunning)
-        node.start()
+        XCTAssertFalse(await node.isRunning)
+        await node.start()
 
-        XCTAssertTrue(node.isRunning)
-        XCTAssertTrue(mock.started)
+        XCTAssertTrue(await node.isRunning)
+        XCTAssertEqual(mock.startCount, 1)
         XCTAssertEqual(mock.bootstrapped, ["1.2.3.4:4001"])
         XCTAssertTrue(mock.natEnabled)
     }
 
-    func testStopShutsDownHost() {
+    func testStopShutsDownHost() async {
         let mock = MockHost()
         let node = P2PNode(hostBuilder: { mock })
-        node.start()
-        node.stop()
+        await node.start()
+        await node.stop()
 
-        XCTAssertFalse(node.isRunning)
-        XCTAssertTrue(mock.stopped)
+        XCTAssertFalse(await node.isRunning)
+        XCTAssertEqual(mock.stopCount, 1)
     }
 
-    func testSendThrowsWhenPeerLacksPublicKey() throws {
+    func testSendThrowsWhenPeerLacksPublicKey() async throws {
         let node = P2PNode()
         let peer = try Peer(latitude: 0, longitude: 0)
         let message = Data("hi".utf8)
 
-        XCTAssertThrowsError(try node.send(message, to: peer)) { error in
+        do {
+            _ = try await node.send(message, to: peer)
+            XCTFail("Expected to throw")
+        } catch {
             XCTAssertEqual(error as? P2PNode.P2PError, .missingPeerPublicKey)
         }
     }
 
-    func testReceiveThrowsWhenPeerLacksPublicKey() throws {
+    func testReceiveThrowsWhenPeerLacksPublicKey() async throws {
         let node = P2PNode()
         let peer = try Peer(latitude: 0, longitude: 0)
         let data = Data("hi".utf8)
 
-        XCTAssertThrowsError(try node.receive(data, from: peer)) { error in
+        do {
+            _ = try await node.receive(data, from: peer)
+            XCTFail("Expected to throw")
+        } catch {
             XCTAssertEqual(error as? P2PNode.P2PError, .missingPeerPublicKey)
         }
+    }
+
+    func testConcurrentStartStop() async {
+        let mock = MockHost()
+        let node = P2PNode(hostBuilder: { mock })
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<10 {
+                group.addTask { await node.start() }
+            }
+        }
+        XCTAssertTrue(await node.isRunning)
+        XCTAssertEqual(mock.startCount, 1)
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<10 {
+                group.addTask { await node.stop() }
+            }
+        }
+        XCTAssertFalse(await node.isRunning)
+        XCTAssertEqual(mock.stopCount, 1)
     }
 }


### PR DESCRIPTION
## Summary
- Convert `P2PNode` into an `actor` and isolate host lifecycle state.
- Update main and tests for new async API, including concurrency stress test for start/stop.

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688fbb33e794832bb3e8a16606e6f92c