### PR TITLE
Handle geohash updates when re-adding peers

### DIFF
--- a/Sources/PeerManager.swift
+++ b/Sources/PeerManager.swift
@@ -62,6 +62,17 @@ final class PeerManager: @unchecked Sendable {
     /// Adds or updates a peer in the manager.
     func add(_ peer: Peer) {
         queue.sync(flags: .barrier) {
+            if let existing = peerIndex[peer.id] {
+                let oldKey = existing.geohash
+                if var bucket = geohashIndex[oldKey] {
+                    bucket.remove(peer.id)
+                    if bucket.isEmpty {
+                        geohashIndex.removeValue(forKey: oldKey)
+                    } else {
+                        geohashIndex[oldKey] = bucket
+                    }
+                }
+            }
             peerIndex[peer.id] = peer
             let key = peer.geohash
             var bucket = geohashIndex[key] ?? Set<UUID>()

--- a/Tests/WeaveTests/PeerManagerTests.swift
+++ b/Tests/WeaveTests/PeerManagerTests.swift
@@ -130,6 +130,21 @@ final class PeerManagerTests: XCTestCase {
         XCTAssertFalse(manager.peers(inGeohash: oldPrefix).contains(updated))
     }
 
+    func testReaddingPeerUpdatesGeohashIndex() {
+        let manager = PeerManager()
+        let id = UUID()
+        let original = try! Peer(id: id, latitude: 0.0, longitude: 0.0)
+        manager.add(original)
+        let oldHash = original.geohash
+
+        let moved = try! Peer(id: id, latitude: 45.0, longitude: 45.0)
+        manager.add(moved)
+
+        XCTAssertEqual(manager.peer(id: id), moved)
+        XCTAssertTrue(manager.peers(inGeohash: oldHash).isEmpty)
+        XCTAssertEqual(manager.peers(inGeohash: moved.geohash), [moved])
+    }
+
     func testUpdatingPeerAttributes() {
         let manager = PeerManager()
         let peer = try! Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "gaming"])


### PR DESCRIPTION
## Summary
- update `PeerManager.add(_:)` to remove old geohash bucket before inserting peer
- test that re-adding a peer moves its geohash index entry

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688fbf247850832b8dfcd7655c009ba0