### PR TITLE
Validate coordinates before updating peer location

### DIFF
--- a/Sources/PeerManager.swift
+++ b/Sources/PeerManager.swift
@@ -99,7 +99,9 @@ final class PeerManager: @unchecked Sendable {
     /// Updates a peer's geographic location if it exists in the manager.
     func updateLocation(id: UUID, latitude: Double, longitude: Double) {
         queue.sync(flags: .barrier) {
-            guard var peer = peerIndex[id] else { return }
+            guard var peer = peerIndex[id],
+                  (-90.0...90.0).contains(latitude),
+                  (-180.0...180.0).contains(longitude) else { return }
             let oldKey = peer.geohash
             peer.latitude = latitude
             peer.longitude = longitude

--- a/Tests/WeaveTests/PeerManagerTests.swift
+++ b/Tests/WeaveTests/PeerManagerTests.swift
@@ -130,6 +130,22 @@ final class PeerManagerTests: XCTestCase {
         XCTAssertFalse(manager.peers(inGeohash: oldPrefix).contains(updated))
     }
 
+    func testUpdateLocationRejectsInvalidCoordinates() {
+        let manager = PeerManager()
+        let peer = try! Peer(latitude: 0.0, longitude: 0.0)
+        manager.add(peer)
+
+        manager.updateLocation(id: peer.id, latitude: 100.0, longitude: 0.0)
+        var updated = manager.peer(id: peer.id)!
+        XCTAssertEqual(updated.latitude, 0.0)
+        XCTAssertEqual(updated.longitude, 0.0)
+
+        manager.updateLocation(id: peer.id, latitude: 0.0, longitude: 200.0)
+        updated = manager.peer(id: peer.id)!
+        XCTAssertEqual(updated.latitude, 0.0)
+        XCTAssertEqual(updated.longitude, 0.0)
+    }
+
     func testUpdatingPeerAttributes() {
         let manager = PeerManager()
         let peer = try! Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "gaming"])


### PR DESCRIPTION
## Summary
- ensure `updateLocation` validates latitude and longitude ranges before updating a peer
- add unit test confirming invalid coordinate updates are ignored

## Testing
- `swift test` *(fails: unable to clone dependency `swift-libp2p`)*

------
https://chatgpt.com/codex/tasks/task_e_688fbf24a960832ba326008523198dca