### PR TITLE
Ensure PeerStore save creates directory

### DIFF
--- a/Sources/PeerStore.swift
+++ b/Sources/PeerStore.swift
@@ -131,6 +131,10 @@ struct PeerStore {
         } catch {
             throw StoreError.encryptionFailed
         }
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
         try sealedBox.combined.write(to: url, options: .atomic)
     }
 

--- a/Tests/WeaveTests/PeerStoreTests.swift
+++ b/Tests/WeaveTests/PeerStoreTests.swift
@@ -42,4 +42,15 @@ final class PeerStoreTests: XCTestCase {
         let perms = attrs[.posixPermissions] as? Int
         XCTAssertEqual(perms, 0o600)
     }
+
+    func testSaveToBrandNewDirectory() throws {
+        let baseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("subdir")
+        let storeURL = baseURL.appendingPathComponent("store.json")
+        let store = PeerStore(url: storeURL)
+        let peer = try Peer(latitude: 1.0, longitude: 2.0)
+        XCTAssertNoThrow(try store.save(peers: [peer], blocked: []))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: storeURL.path))
+    }
 }


### PR DESCRIPTION
## Summary
- Ensure `PeerStore.save` creates parent directories before writing encrypted data
- Add regression test for saving into a brand-new directory

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688fbf260ff0832bbcf51ec0fcf8eb8d