### PR TITLE
Add LRU eviction for shared key cache

### DIFF
--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -44,6 +44,10 @@ actor P2PNode {
     /// Public key that can be shared with peers.
     let publicKey: Data
 
+    /// Maximum number of peers to retain in the shared key cache.
+    private let maxCachedPeers = 100
+    /// Tracks peer access order for LRU eviction.
+    private var accessOrder: [UUID] = []
     /// Cache of derived symmetric keys for peers, keyed by peer ID.
     private var sharedKeyCache: [UUID: SymmetricKey] = [:]
     /// Tracks the public key used when deriving the cached shared key.
@@ -109,11 +113,14 @@ actor P2PNode {
             throw P2PError.missingPeerPublicKey
         }
         if let cachedKey = sharedKeyCache[peer.id], cachedPublicKeys[peer.id] == publicKey {
+            refreshAccessOrder(for: peer.id)
             return cachedKey
         }
         let key = try keyDerivation(privateKey, publicKey)
         sharedKeyCache[peer.id] = key
         cachedPublicKeys[peer.id] = publicKey
+        refreshAccessOrder(for: peer.id)
+        evictIfNeeded()
         return key
     }
 
@@ -122,6 +129,24 @@ actor P2PNode {
     func invalidateSharedKey(for peerID: UUID) {
         sharedKeyCache.removeValue(forKey: peerID)
         cachedPublicKeys.removeValue(forKey: peerID)
+        accessOrder.removeAll { $0 == peerID }
+    }
+
+    /// Records access to a peer's cached key.
+    private func refreshAccessOrder(for peerID: UUID) {
+        if let index = accessOrder.firstIndex(of: peerID) {
+            accessOrder.remove(at: index)
+        }
+        accessOrder.append(peerID)
+    }
+
+    /// Removes least recently used entries when the cache exceeds its limit.
+    private func evictIfNeeded() {
+        if accessOrder.count > maxCachedPeers, let lru = accessOrder.first {
+            accessOrder.removeFirst()
+            sharedKeyCache.removeValue(forKey: lru)
+            cachedPublicKeys.removeValue(forKey: lru)
+        }
     }
 
     enum P2PError: Error {

--- a/Tests/WeaveTests/P2PNodeTests.swift
+++ b/Tests/WeaveTests/P2PNodeTests.swift
@@ -86,4 +86,41 @@ final class P2PNodeTests: XCTestCase {
         XCTAssertEqual(derivationCalls, 2)
 
     }
+
+    func testCacheEvictsLeastRecentlyUsedPeer() throws {
+        var derivationCalls = 0
+        let node = P2PNode(keyDerivation: { privateKey, peerPublicKey in
+            derivationCalls += 1
+            return try Encryption.deriveSharedSecret(privateKey: privateKey, peerPublicKey: peerPublicKey)
+        })
+
+        let message = Data("hi".utf8)
+        var peers: [Peer] = []
+
+        // Fill the cache to its limit
+        for _ in 0..<100 {
+            let keys = Encryption.generateKeyPair()
+            let peer = try Peer(publicKey: keys.publicKey, latitude: 0, longitude: 0)
+            peers.append(peer)
+            _ = try node.send(message, to: peer)
+        }
+
+        // Access the first peer again so it becomes most recently used
+        _ = try node.send(message, to: peers[0])
+        XCTAssertEqual(derivationCalls, 100)
+
+        // Add a new peer which should evict the least recently used (peers[1])
+        let extraKeys = Encryption.generateKeyPair()
+        let extraPeer = try Peer(publicKey: extraKeys.publicKey, latitude: 0, longitude: 0)
+        _ = try node.send(message, to: extraPeer)
+        XCTAssertEqual(derivationCalls, 101)
+
+        // Sending to peers[1] should derive again since it was evicted
+        _ = try node.send(message, to: peers[1])
+        XCTAssertEqual(derivationCalls, 102)
+
+        // peers[0] should still be cached
+        _ = try node.send(message, to: peers[0])
+        XCTAssertEqual(derivationCalls, 102)
+    }
 }


### PR DESCRIPTION
## Summary
- limit cached shared keys to 100 peers using LRU eviction
- refresh access order on shared key use and remove least recently used entries
- test cache eviction behaviour when exceeding limit

## Testing
- `swift test` *(fails: unable to clone https://github.com/libp2p/swift-libp2p.git)*

------
https://chatgpt.com/codex/tasks/task_e_688fbf2622d0832bbf065862cb3c8b60