### PR TITLE
Refactor PeerManager to actor

### DIFF
--- a/Sources/PeerManager.swift
+++ b/Sources/PeerManager.swift
@@ -1,204 +1,166 @@
 import Foundation
-import Dispatch
 
 /// Manages known peers and provides basic discovery utilities.
-final class PeerManager: @unchecked Sendable {
+actor PeerManager {
 
     private var peerIndex: [UUID: Peer] = [:]
     private var blocked: Set<UUID> = []
     private var liked: Set<UUID> = []
     /// Maps full geohashes to the IDs of peers within that cell.
     private var geohashIndex: [String: Set<UUID>] = [:]
-    private let queue = DispatchQueue(label: "PeerManager.queue", attributes: .concurrent)
 
     /// Marks a peer as blocked, excluding it from discovery APIs.
     func block(id: UUID) {
-        queue.sync(flags: .barrier) {
-            blocked.insert(id)
-            liked.remove(id)
-        }
+        blocked.insert(id)
+        liked.remove(id)
     }
 
     /// Removes a peer from the blocked list.
     func unblock(id: UUID) {
-        _ = queue.sync(flags: .barrier) {
-            blocked.remove(id)
-        }
+        blocked.remove(id)
     }
 
     /// Marks a peer as liked if it exists and is not blocked.
     func like(id: UUID) {
-        queue.sync(flags: .barrier) {
-            guard peerIndex[id] != nil, !blocked.contains(id) else { return }
-            liked.insert(id)
-        }
+        guard peerIndex[id] != nil, !blocked.contains(id) else { return }
+        liked.insert(id)
     }
 
     /// Removes a peer from the liked list.
     func unlike(id: UUID) {
-        _ = queue.sync(flags: .barrier) {
-            liked.remove(id)
-        }
+        liked.remove(id)
     }
 
     /// Returns all liked peers that are not currently blocked.
     func likedPeers() -> [Peer] {
-        queue.sync {
-            liked.compactMap { peerIndex[$0] }.filter { !blocked.contains($0.id) }
-        }
+        liked.compactMap { peerIndex[$0] }.filter { !blocked.contains($0.id) }
     }
 
     /// Returns liked peers that have indicated they like the given user.
     /// A peer is considered a mutual match if its attributes contain the
     /// provided `userID` under the key "likes".
     func mutualLikes(for userID: UUID) -> [Peer] {
-        queue.sync {
-            liked.compactMap { peerIndex[$0] }
-                .filter { $0.attributes["likes"] == userID.uuidString && !blocked.contains($0.id) }
-        }
+        liked.compactMap { peerIndex[$0] }
+            .filter { $0.attributes["likes"] == userID.uuidString && !blocked.contains($0.id) }
     }
 
 
     /// Adds or updates a peer in the manager.
     func add(_ peer: Peer) {
-        queue.sync(flags: .barrier) {
-            peerIndex[peer.id] = peer
-            let key = peer.geohash
-            var bucket = geohashIndex[key] ?? Set<UUID>()
-            bucket.insert(peer.id)
-            geohashIndex[key] = bucket
-        }
+        peerIndex[peer.id] = peer
+        let key = peer.geohash
+        var bucket = geohashIndex[key] ?? Set<UUID>()
+        bucket.insert(peer.id)
+        geohashIndex[key] = bucket
     }
 
     /// Removes a peer by id.
     func remove(id: UUID) {
-        queue.sync(flags: .barrier) {
-            if let peer = peerIndex.removeValue(forKey: id) {
-                let key = peer.geohash
-                if var bucket = geohashIndex[key] {
-                    bucket.remove(id)
-                    if bucket.isEmpty {
-                        geohashIndex.removeValue(forKey: key)
-                    } else {
-                        geohashIndex[key] = bucket
-                    }
+        if let peer = peerIndex.removeValue(forKey: id) {
+            let key = peer.geohash
+            if var bucket = geohashIndex[key] {
+                bucket.remove(id)
+                if bucket.isEmpty {
+                    geohashIndex.removeValue(forKey: key)
+                } else {
+                    geohashIndex[key] = bucket
                 }
             }
-            blocked.remove(id)
-            liked.remove(id)
         }
+        blocked.remove(id)
+        liked.remove(id)
     }
 
     /// Returns the peer with the given id, if present.
     func peer(id: UUID) -> Peer? {
-        queue.sync {
-            peerIndex[id]
-        }
+        peerIndex[id]
     }
 
     /// Updates a peer's geographic location if it exists in the manager.
     func updateLocation(id: UUID, latitude: Double, longitude: Double) {
-        queue.sync(flags: .barrier) {
-            guard var peer = peerIndex[id] else { return }
-            let oldKey = peer.geohash
-            peer.latitude = latitude
-            peer.longitude = longitude
-            peer.lastSeen = Date()
-            peerIndex[id] = peer
-            let newKey = peer.geohash
-            if oldKey != newKey {
-                if var bucket = geohashIndex[oldKey] {
-                    bucket.remove(id)
-                    if bucket.isEmpty {
-                        geohashIndex.removeValue(forKey: oldKey)
-                    } else {
-                        geohashIndex[oldKey] = bucket
-                    }
+        guard var peer = peerIndex[id] else { return }
+        let oldKey = peer.geohash
+        peer.latitude = latitude
+        peer.longitude = longitude
+        peer.lastSeen = Date()
+        peerIndex[id] = peer
+        let newKey = peer.geohash
+        if oldKey != newKey {
+            if var bucket = geohashIndex[oldKey] {
+                bucket.remove(id)
+                if bucket.isEmpty {
+                    geohashIndex.removeValue(forKey: oldKey)
+                } else {
+                    geohashIndex[oldKey] = bucket
                 }
-                var newBucket = geohashIndex[newKey] ?? Set<UUID>()
-                newBucket.insert(id)
-                geohashIndex[newKey] = newBucket
             }
+            var newBucket = geohashIndex[newKey] ?? Set<UUID>()
+            newBucket.insert(id)
+            geohashIndex[newKey] = newBucket
         }
     }
 
     /// Replaces a peer's attributes dictionary if it exists in the manager.
     func updateAttributes(id: UUID, attributes: [String: String]) {
-        queue.sync(flags: .barrier) {
-            guard var peer = peerIndex[id] else { return }
-            peer.attributes = attributes
-            peer.lastSeen = Date()
-            peerIndex[id] = peer
-        }
+        guard var peer = peerIndex[id] else { return }
+        peer.attributes = attributes
+        peer.lastSeen = Date()
+        peerIndex[id] = peer
     }
 
     /// Sets or replaces a single attribute on the peer if present.
     func updateAttribute(id: UUID, key: String, value: String) {
-        queue.sync(flags: .barrier) {
-            guard var peer = peerIndex[id] else { return }
-            peer.attributes[key] = value
-            peer.lastSeen = Date()
-            peerIndex[id] = peer
-        }
+        guard var peer = peerIndex[id] else { return }
+        peer.attributes[key] = value
+        peer.lastSeen = Date()
+        peerIndex[id] = peer
     }
 
     /// Removes a single attribute from the peer if present.
     func removeAttribute(id: UUID, key: String) {
-        queue.sync(flags: .barrier) {
-            guard var peer = peerIndex[id] else { return }
-            peer.attributes.removeValue(forKey: key)
-            peer.lastSeen = Date()
-            peerIndex[id] = peer
-        }
+        guard var peer = peerIndex[id] else { return }
+        peer.attributes.removeValue(forKey: key)
+        peer.lastSeen = Date()
+        peerIndex[id] = peer
     }
 
     /// Updates a peer's network address and port if it exists in the manager.
     func updateAddress(id: UUID, address: String?, port: UInt16?) {
-        queue.sync(flags: .barrier) {
-            guard var peer = peerIndex[id] else { return }
-            peer.address = address
-            peer.port = port
-            peer.lastSeen = Date()
-            peerIndex[id] = peer
-        }
+        guard var peer = peerIndex[id] else { return }
+        peer.address = address
+        peer.port = port
+        peer.lastSeen = Date()
+        peerIndex[id] = peer
     }
 
     /// Updates a peer's display name if it exists in the manager.
     func updateName(id: UUID, name: String?) {
-        queue.sync(flags: .barrier) {
-            guard var peer = peerIndex[id] else { return }
-            peer.name = name
-            peer.lastSeen = Date()
-            peerIndex[id] = peer
-        }
+        guard var peer = peerIndex[id] else { return }
+        peer.name = name
+        peer.lastSeen = Date()
+        peerIndex[id] = peer
     }
 
     /// Updates the last-seen timestamp for the given peer to the provided date (defaults to now).
     func updateLastSeen(id: UUID, at date: Date = Date()) {
-        queue.sync(flags: .barrier) {
-            guard var peer = peerIndex[id] else { return }
-            peer.lastSeen = date
-            peerIndex[id] = peer
-        }
+        guard var peer = peerIndex[id] else { return }
+        peer.lastSeen = date
+        peerIndex[id] = peer
     }
 
     /// Simulates connecting to the peer with the given id. Returns `true` if the
     /// peer exists and is not blocked. A successful connection refreshes the
     /// peer's last-seen timestamp.
     func connect(to id: UUID) -> Bool {
-        queue.sync(flags: .barrier) {
-            guard var peer = peerIndex[id], !blocked.contains(id) else { return false }
-            peer.lastSeen = Date()
-            peerIndex[id] = peer
-            return true
-        }
+        guard var peer = peerIndex[id], !blocked.contains(id) else { return false }
+        peer.lastSeen = Date()
+        peerIndex[id] = peer
+        return true
     }
 
     /// Returns all known peers.
     func allPeers() -> [Peer] {
-        queue.sync {
-            peerIndex.values.filter { !blocked.contains($0.id) }
-        }
+        peerIndex.values.filter { !blocked.contains($0.id) }
     }
 
     /// Returns peers within the given radius (in kilometers) of the provided location.
@@ -207,12 +169,10 @@ final class PeerManager: @unchecked Sendable {
                longitude: Double,
                radius: Double,
                matching filters: [String: String] = [:]) -> [Peer] {
-        queue.sync {
-            peerIndex.values.filter { peer in
-                !blocked.contains(peer.id) &&
-                distance(from: (latitude, longitude), to: (peer.latitude, peer.longitude)) <= radius &&
-                filters.allSatisfy { key, value in peer.attributes[key] == value }
-            }
+        peerIndex.values.filter { peer in
+            !blocked.contains(peer.id) &&
+            distance(from: (latitude, longitude), to: (peer.latitude, peer.longitude)) <= radius &&
+            filters.allSatisfy { key, value in peer.attributes[key] == value }
         }
     }
 
@@ -227,20 +187,18 @@ final class PeerManager: @unchecked Sendable {
     /// Returns peers in the specified geohash prefix that match all provided
     /// attribute filters.
     func peers(inGeohash prefix: String, matching filters: [String: String]) -> [Peer] {
-        queue.sync {
-            let ids = geohashIndex.reduce(into: Set<UUID>()) { result, entry in
-                if entry.key.hasPrefix(prefix) {
-                    result.formUnion(entry.value)
-                }
+        let ids = geohashIndex.reduce(into: Set<UUID>()) { result, entry in
+            if entry.key.hasPrefix(prefix) {
+                result.formUnion(entry.value)
             }
-            return ids.compactMap { id in
-                guard let peer = peerIndex[id],
-                      !blocked.contains(id),
-                      peer.geohash.hasPrefix(prefix),
-                      filters.allSatisfy({ k, v in peer.attributes[k] == v })
-                else { return nil }
-                return peer
-            }
+        }
+        return ids.compactMap { id in
+            guard let peer = peerIndex[id],
+                  !blocked.contains(id),
+                  peer.geohash.hasPrefix(prefix),
+                  filters.allSatisfy({ k, v in peer.attributes[k] == v })
+            else { return nil }
+            return peer
         }
     }
 
@@ -251,74 +209,65 @@ final class PeerManager: @unchecked Sendable {
                       longitude: Double,
                       limit: Int,
                       matching filters: [String: String] = [:]) -> [Peer] {
-        queue.sync {
-            let candidates = peerIndex.values
-                .filter { peer in
-                    !blocked.contains(peer.id) &&
-                    filters.allSatisfy { key, value in peer.attributes[key] == value }
-                }
-                .map { peer -> (peer: Peer, distance: Double) in
-                    let dist = distance(from: (latitude, longitude),
-                                        to: (peer.latitude, peer.longitude))
-                    return (peer, dist)
-                }
-                .sorted { $0.distance < $1.distance }
+        let candidates = peerIndex.values
+            .filter { peer in
+                !blocked.contains(peer.id) &&
+                filters.allSatisfy { key, value in peer.attributes[key] == value }
+            }
+            .map { peer -> (peer: Peer, distance: Double) in
+                let dist = distance(from: (latitude, longitude),
+                                    to: (peer.latitude, peer.longitude))
+                return (peer, dist)
+            }
+            .sorted { $0.distance < $1.distance }
 
-            return candidates.prefix(limit).map { $0.peer }
-        }
+        return candidates.prefix(limit).map { $0.peer }
     }
 
     /// Returns up to `limit` most recently seen peers, excluding any that are blocked.
     func recentPeers(limit: Int) -> [Peer] {
-        queue.sync {
-            let sorted = peerIndex.values
-                .filter { !blocked.contains($0.id) }
-                .sorted { $0.lastSeen > $1.lastSeen }
-            return Array(sorted.prefix(limit))
-        }
+        let sorted = peerIndex.values
+            .filter { !blocked.contains($0.id) }
+            .sorted { $0.lastSeen > $1.lastSeen }
+        return Array(sorted.prefix(limit))
     }
 
     /// Returns up to `limit` peers within `radius` kilometers of the given peer,
     /// ranked first by number of matching attribute key/value pairs and then by
     /// proximity (closest first).
     func matchPeers(for peer: Peer, radius: Double, limit: Int) -> [Peer] {
-        queue.sync {
-            let results: [(peer: Peer, score: Int, distance: Double)] = peerIndex.values.compactMap { candidate in
-                guard candidate.id != peer.id, !blocked.contains(candidate.id) else { return nil }
-                let dist = distance(from: (peer.latitude, peer.longitude), to: (candidate.latitude, candidate.longitude))
-                guard dist <= radius else { return nil }
+        let results: [(peer: Peer, score: Int, distance: Double)] = peerIndex.values.compactMap { candidate in
+            guard candidate.id != peer.id, !blocked.contains(candidate.id) else { return nil }
+            let dist = distance(from: (peer.latitude, peer.longitude), to: (candidate.latitude, candidate.longitude))
+            guard dist <= radius else { return nil }
 
-                let score = peer.attributes.reduce(0) { acc, pair in
-                    acc + (candidate.attributes[pair.key] == pair.value ? 1 : 0)
-                }
-                return (candidate, score, dist)
+            let score = peer.attributes.reduce(0) { acc, pair in
+                acc + (candidate.attributes[pair.key] == pair.value ? 1 : 0)
             }
-
-            return results
-                .sorted { lhs, rhs in
-                    if lhs.score == rhs.score {
-                        return lhs.distance < rhs.distance
-                    } else {
-                        return lhs.score > rhs.score
-                    }
-                }
-                .prefix(limit)
-                .map { $0.peer }
+            return (candidate, score, dist)
         }
+
+        return results
+            .sorted { lhs, rhs in
+                if lhs.score == rhs.score {
+                    return lhs.distance < rhs.distance
+                } else {
+                    return lhs.score > rhs.score
+                }
+            }
+            .prefix(limit)
+            .map { $0.peer }
     }
 
     /// Removes peers that were last seen before the provided cutoff date.
     func pruneStale(before cutoff: Date) {
 
-        queue.sync(flags: .barrier) {
-            peerIndex = peerIndex.filter { $0.value.lastSeen >= cutoff }
-            blocked = blocked.filter { peerIndex[$0] != nil }
+        peerIndex = peerIndex.filter { $0.value.lastSeen >= cutoff }
+        blocked = blocked.filter { peerIndex[$0] != nil }
 
-            liked = liked.filter { peerIndex[$0] != nil && !blocked.contains($0) }
-            geohashIndex = Dictionary(grouping: peerIndex.values, by: { $0.geohash })
-                .mapValues { Set($0.map { $0.id }) }
-
-        }
+        liked = liked.filter { peerIndex[$0] != nil && !blocked.contains($0) }
+        geohashIndex = Dictionary(grouping: peerIndex.values, by: { $0.geohash })
+            .mapValues { Set($0.map { $0.id }) }
 
     }
 
@@ -337,22 +286,22 @@ final class PeerManager: @unchecked Sendable {
 
     /// Persists all known peers along with blocked and liked IDs using the provided store.
     func save(to store: PeerStore) throws {
-        let snapshot = queue.sync { (Array(peerIndex.values), Array(blocked), Array(liked)) }
-        try store.save(peers: snapshot.0,
-                      blocked: snapshot.1,
-                      liked: snapshot.2)
+        let peers = Array(peerIndex.values)
+        let blockedIDs = Array(blocked)
+        let likedIDs = Array(liked)
+        try store.save(peers: peers,
+                       blocked: blockedIDs,
+                       liked: likedIDs)
     }
 
     /// Loads peers (and blocked/liked IDs) from the provided store, replacing any existing data.
     func load(from store: PeerStore) throws {
         let snapshot = try store.load()
-        queue.sync(flags: .barrier) {
-            peerIndex = Dictionary(uniqueKeysWithValues: snapshot.peers.map { ($0.id, $0) })
-            blocked = Set(snapshot.blocked.filter { peerIndex[$0] != nil })
-            liked = Set(snapshot.liked.filter { peerIndex[$0] != nil && !blocked.contains($0) })
-            geohashIndex = Dictionary(grouping: snapshot.peers, by: { $0.geohash })
-                .mapValues { Set($0.map { $0.id }) }
-        }
+        peerIndex = Dictionary(uniqueKeysWithValues: snapshot.peers.map { ($0.id, $0) })
+        blocked = Set(snapshot.blocked.filter { peerIndex[$0] != nil })
+        liked = Set(snapshot.liked.filter { peerIndex[$0] != nil && !blocked.contains($0) })
+        geohashIndex = Dictionary(grouping: snapshot.peers, by: { $0.geohash })
+            .mapValues { Set($0.map { $0.id }) }
     }
 
 }

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -18,72 +18,72 @@ struct Main {
 
         // Add a peer in San Francisco
         let movingPeer = try! Peer(name: "Alice", latitude: 37.7750, longitude: -122.4183, attributes: ["hobby": "hiking", "likes": me.id.uuidString])
-        manager.add(movingPeer)
+        await manager.add(movingPeer)
 
         // Add another peer in Los Angeles with the same hobby
         let laPeer = try! Peer(name: "Bob", latitude: 34.0522, longitude: -118.2437, attributes: ["hobby": "hiking"])
 
-        manager.add(laPeer)
+        await manager.add(laPeer)
 
         // Query peers sharing the same geohash prefix as the moving peer (coarse area
         // match) and demonstrate attribute filtering.
         let prefix = String(movingPeer.geohash.prefix(5))
-        let geohashPeers = manager.peers(inGeohash: prefix)
+        let geohashPeers = await manager.peers(inGeohash: prefix)
         print("Peers in geohash prefix \(prefix): \(geohashPeers.count)")
-        let hikingInPrefix = manager.peers(inGeohash: prefix, matching: ["hobby": "hiking"])
+        let hikingInPrefix = await manager.peers(inGeohash: prefix, matching: ["hobby": "hiking"])
         print("Hiking peers in geohash prefix \(prefix): \(hikingInPrefix.count)")
 
-        var nearbyPeers = manager.peers(near: selfLat, longitude: selfLon, radius: 5000.0)
+        var nearbyPeers = await manager.peers(near: selfLat, longitude: selfLon, radius: 5000.0)
         print("Peers within 5000km: \(nearbyPeers.count)")
 
         // Connect to the moving peer and refresh its last-seen timestamp
-        if manager.connect(to: movingPeer.id) {
+        if await manager.connect(to: movingPeer.id) {
             print("Connected to moving peer")
         }
 
         // Like and then unlike the moving peer
-        manager.like(id: movingPeer.id)
-        print("Liked peers: \(manager.likedPeers().count)")
-        manager.unlike(id: movingPeer.id)
-        print("Liked peers after unlike: \(manager.likedPeers().count)")
+        await manager.like(id: movingPeer.id)
+        print("Liked peers: \(await manager.likedPeers().count)")
+        await manager.unlike(id: movingPeer.id)
+        print("Liked peers after unlike: \(await manager.likedPeers().count)")
         // Like again to demonstrate mutual match detection
-        manager.like(id: movingPeer.id)
-        let mutual = manager.mutualLikes(for: me.id)
+        await manager.like(id: movingPeer.id)
+        let mutual = await manager.mutualLikes(for: me.id)
         print("Mutual matches: \(mutual.count)")
 
         // Block the Los Angeles peer
-        manager.block(id: laPeer.id)
-        nearbyPeers = manager.peers(near: selfLat, longitude: selfLon, radius: 5000.0)
+        await manager.block(id: laPeer.id)
+        nearbyPeers = await manager.peers(near: selfLat, longitude: selfLon, radius: 5000.0)
         print("Peers after blocking LA user: \(nearbyPeers.count)")
 
         // Update the peer's location to New York
-        manager.updateLocation(id: movingPeer.id, latitude: 40.7128, longitude: -74.0060)
-        nearbyPeers = manager.peers(near: selfLat, longitude: selfLon, radius: 5.0)
+        await manager.updateLocation(id: movingPeer.id, latitude: 40.7128, longitude: -74.0060)
+        nearbyPeers = await manager.peers(near: selfLat, longitude: selfLon, radius: 5.0)
         print("Nearby peers after move: \(nearbyPeers.count)")
 
         // Update the peer's network address
-        manager.updateAddress(id: movingPeer.id, address: "203.0.113.1", port: 8080)
-        if let updated = manager.peer(id: movingPeer.id) {
+        await manager.updateAddress(id: movingPeer.id, address: "203.0.113.1", port: 8080)
+        if let updated = await manager.peer(id: movingPeer.id) {
             print("Peer network address: \(updated.address ?? "n/a"):\(updated.port ?? 0)")
         }
 
         // Change the peer's display name
-        manager.updateName(id: movingPeer.id, name: "Traveler")
-        print("Peer name after update: \(manager.peer(id: movingPeer.id)?.name ?? "none")")
+        await manager.updateName(id: movingPeer.id, name: "Traveler")
+        print("Peer name after update: \(await manager.peer(id: movingPeer.id)?.name ?? "none")")
 
         // Update a single attribute and then remove it
-        manager.updateAttribute(id: movingPeer.id, key: "hobby", value: "climbing")
-        print("Updated hobby: \(manager.peer(id: movingPeer.id)?.attributes["hobby"] ?? "none")")
-        manager.removeAttribute(id: movingPeer.id, key: "hobby")
-        print("Hobby after removal: \(manager.peer(id: movingPeer.id)?.attributes["hobby"] ?? "none")")
+        await manager.updateAttribute(id: movingPeer.id, key: "hobby", value: "climbing")
+        print("Updated hobby: \(await manager.peer(id: movingPeer.id)?.attributes["hobby"] ?? "none")")
+        await manager.removeAttribute(id: movingPeer.id, key: "hobby")
+        print("Hobby after removal: \(await manager.peer(id: movingPeer.id)?.attributes["hobby"] ?? "none")")
 
-        let hikers = manager.peers(near: selfLat, longitude: selfLon, radius: 5000.0, matching: ["hobby": "hiking"])
+        let hikers = await manager.peers(near: selfLat, longitude: selfLon, radius: 5000.0, matching: ["hobby": "hiking"])
         print("Hikers within 5000km: \(hikers.count)")
 
-        let matches = manager.matchPeers(for: me, radius: 5000.0, limit: 5)
+        let matches = await manager.matchPeers(for: me, radius: 5000.0, limit: 5)
         print("Top matches by hobby within 5000km: \(matches.count)")
 
-        let nearestHikers = manager.nearestPeers(to: selfLat,
+        let nearestHikers = await manager.nearestPeers(to: selfLat,
                                                  longitude: selfLon,
                                                  limit: 3,
                                                  matching: ["hobby": "hiking"])
@@ -92,22 +92,22 @@ struct Main {
         // Persist peers to disk and load them back
         let storeURL = URL(fileURLWithPath: "/tmp/peers.json")
         let store = PeerStore(url: storeURL)
-        try? manager.save(to: store)
+        try? await manager.save(to: store)
         let restored = PeerManager()
-        try? restored.load(from: store)
-        print("Restored \(restored.allPeers().count) peer(s) from disk (blocked peers excluded)")
-        restored.unblock(id: laPeer.id)
-        print("After unblocking LA user post-restore: \(restored.allPeers().count) peer(s)")
+        try? await restored.load(from: store)
+        print("Restored \(await restored.allPeers().count) peer(s) from disk (blocked peers excluded)")
+        await restored.unblock(id: laPeer.id)
+        print("After unblocking LA user post-restore: \(await restored.allPeers().count) peer(s)")
 
         // Demonstrate pruning stale peers
         let stalePeer = try! Peer(latitude: 35.0, longitude: -120.0, lastSeen: Date(timeIntervalSinceNow: -7200))
-        manager.add(stalePeer)
-        print("Total peers before pruning: \(manager.allPeers().count)")
-        manager.pruneStale(before: Date(timeIntervalSinceNow: -3600))
-        print("Peers after pruning stale entries: \(manager.allPeers().count)")
+        await manager.add(stalePeer)
+        print("Total peers before pruning: \(await manager.allPeers().count)")
+        await manager.pruneStale(before: Date(timeIntervalSinceNow: -3600))
+        print("Peers after pruning stale entries: \(await manager.allPeers().count)")
 
         // Fetch the most recently seen peers
-        let recent = manager.recentPeers(limit: 2)
+        let recent = await manager.recentPeers(limit: 2)
         print("Most recently seen peers: \(recent.count)")
 
         await node.stop()

--- a/Tests/WeaveTests/LocationServiceTests.swift
+++ b/Tests/WeaveTests/LocationServiceTests.swift
@@ -4,16 +4,18 @@ import CoreLocation
 @testable import weave
 
 final class LocationServiceTests: XCTestCase {
-    func testLocationUpdatesFeedPeerManager() throws {
+    func testLocationUpdatesFeedPeerManager() async throws {
         let expectation = expectation(description: "location update")
         let service = LocationService()
         let manager = PeerManager()
         let peer = try Peer(latitude: 0.0, longitude: 0.0)
-        manager.add(peer)
+        await manager.add(peer)
 
         service.onLocationUpdate = { lat, lon in
-            manager.updateLocation(id: peer.id, latitude: lat, longitude: lon)
-            expectation.fulfill()
+            Task {
+                await manager.updateLocation(id: peer.id, latitude: lat, longitude: lon)
+                expectation.fulfill()
+            }
         }
 
         // Simulate a location update
@@ -21,7 +23,7 @@ final class LocationServiceTests: XCTestCase {
         service.locationManager(CLLocationManager(), didUpdateLocations: [simulated])
 
         waitForExpectations(timeout: 1.0)
-        let updated = manager.peer(id: peer.id)
+        let updated = await manager.peer(id: peer.id)
         XCTAssertEqual(updated?.latitude, 50.0)
         XCTAssertEqual(updated?.longitude, 8.0)
 

--- a/Tests/WeaveTests/PeerManagerTests.swift
+++ b/Tests/WeaveTests/PeerManagerTests.swift
@@ -1,64 +1,63 @@
 import XCTest
 
 import Foundation
-import Dispatch
 @testable import weave
 
 final class PeerManagerTests: XCTestCase {
-    func testFiltersNearbyPeers() {
+    func testFiltersNearbyPeers() async {
 
         let manager = PeerManager()
         let userLocation = try! Peer(latitude: 37.7749, longitude: -122.4194)
         let nearby = try! Peer(latitude: 37.7750, longitude: -122.4195)
         let farAway = try! Peer(latitude: 40.7128, longitude: -74.0060)
 
-        manager.add(nearby)
-        manager.add(farAway)
+        await manager.add(nearby)
+        await manager.add(farAway)
 
 
-        let filteredPeers = manager.peers(near: userLocation.latitude, longitude: userLocation.longitude, radius: 10.0)
+        let filteredPeers = await manager.peers(near: userLocation.latitude, longitude: userLocation.longitude, radius: 10.0)
         XCTAssertTrue(filteredPeers.contains(nearby))
         XCTAssertFalse(filteredPeers.contains(farAway))
     }
 
-    func testRemovingPeerUpdatesIndex() {
+    func testRemovingPeerUpdatesIndex() async {
         let manager = PeerManager()
         let peer = try! Peer(latitude: 37.0, longitude: -122.0)
-        manager.add(peer)
-        XCTAssertEqual(manager.allPeers().count, 1)
+        await manager.add(peer)
+        XCTAssertEqual(await manager.allPeers().count, 1)
         let prefix = String(peer.geohash.prefix(5))
-        XCTAssertEqual(manager.peers(inGeohash: prefix), [peer])
-        manager.remove(id: peer.id)
-        XCTAssertEqual(manager.allPeers().count, 0)
-        XCTAssertTrue(manager.peers(inGeohash: prefix).isEmpty)
+        XCTAssertEqual(await manager.peers(inGeohash: prefix), [peer])
+        await manager.remove(id: peer.id)
+        XCTAssertEqual(await manager.allPeers().count, 0)
+        XCTAssertTrue(await manager.peers(inGeohash: prefix).isEmpty)
     }
 
-    func testNearestPeersReturnsSortedResults() {
+    func testNearestPeersReturnsSortedResults() async {
         let manager = PeerManager()
         let origin = try! Peer(latitude: 0.0, longitude: 0.0)
         let nearer = try! Peer(latitude: 0.0, longitude: 0.05) // ~5.5km east
         let near = try! Peer(latitude: 0.0, longitude: 0.1)   // ~11km east
 
-        manager.add(near)
-        manager.add(nearer)
+        await manager.add(near)
+        await manager.add(nearer)
 
-        let results = manager.nearestPeers(to: origin.latitude, longitude: origin.longitude, limit: 2)
+        let results = await manager.nearestPeers(to: origin.latitude, longitude: origin.longitude, limit: 2)
         XCTAssertEqual(results.count, 2)
         XCTAssertEqual(results[0], nearer)
         XCTAssertEqual(results[1], near)
 
     }
 
-    func testNearestPeersRespectsAttributeFilters() {
+    func testNearestPeersRespectsAttributeFilters() async {
         let manager = PeerManager()
         let origin = try! Peer(latitude: 0.0, longitude: 0.0)
         let hikingPeer = try! Peer(latitude: 0.0, longitude: 0.05, attributes: ["hobby": "hiking"])
         let gamingPeer = try! Peer(latitude: 0.0, longitude: 0.02, attributes: ["hobby": "gaming"])
 
-        manager.add(hikingPeer)
-        manager.add(gamingPeer)
+        await manager.add(hikingPeer)
+        await manager.add(gamingPeer)
 
-        let results = manager.nearestPeers(to: origin.latitude,
+        let results = await manager.nearestPeers(to: origin.latitude,
                                            longitude: origin.longitude,
                                            limit: 5,
                                            matching: ["hobby": "hiking"])
@@ -66,7 +65,7 @@ final class PeerManagerTests: XCTestCase {
 
     }
 
-    func testNearestPeersMatchesNaiveImplementation() {
+    func testNearestPeersMatchesNaiveImplementation() async {
         let manager = PeerManager()
         let originLat = 0.0
         let originLon = 0.0
@@ -79,9 +78,9 @@ final class PeerManagerTests: XCTestCase {
             Peer(latitude: -0.2, longitude: 0.0)
         ]
 
-        peers.forEach { manager.add($0) }
+        for peer in peers { await manager.add(peer) }
 
-        let optimized = manager.nearestPeers(to: originLat, longitude: originLon, limit: 5)
+        let optimized = await manager.nearestPeers(to: originLat, longitude: originLon, limit: 5)
 
         func distance(_ from: (Double, Double), _ to: (Double, Double)) -> Double {
             let earthRadiusKm = 6371.0
@@ -94,7 +93,7 @@ final class PeerManagerTests: XCTestCase {
             return earthRadiusKm * c
         }
 
-        let naive = manager.allPeers().sorted {
+        let naive = await manager.allPeers().sorted {
             distance((originLat, originLon), ($0.latitude, $0.longitude)) <
             distance((originLat, originLon), ($1.latitude, $1.longitude))
         }
@@ -102,291 +101,291 @@ final class PeerManagerTests: XCTestCase {
         XCTAssertEqual(optimized, Array(naive.prefix(5)))
     }
 
-    func testAttributeFilteringReturnsMatches() {
+    func testAttributeFilteringReturnsMatches() async {
         let manager = PeerManager()
         let hiker = try! Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "hiking"])
         let gamer = try! Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "gaming"])
 
-        manager.add(hiker)
-        manager.add(gamer)
+        await manager.add(hiker)
+        await manager.add(gamer)
 
-        let results = manager.peers(near: 0.0, longitude: 0.0, radius: 1.0, matching: ["hobby": "hiking"])
+        let results = await manager.peers(near: 0.0, longitude: 0.0, radius: 1.0, matching: ["hobby": "hiking"])
         XCTAssertEqual(results, [hiker])
 
     }
 
-    func testUpdatingPeerLocation() {
+    func testUpdatingPeerLocation() async {
         let manager = PeerManager()
         let peer = try! Peer(latitude: 0.0, longitude: 0.0)
-        manager.add(peer)
+        await manager.add(peer)
         let oldPrefix = String(peer.geohash.prefix(5))
-        manager.updateLocation(id: peer.id, latitude: 1.0, longitude: 1.0)
-        let updated = manager.peer(id: peer.id)!
+        await manager.updateLocation(id: peer.id, latitude: 1.0, longitude: 1.0)
+        let updated = await manager.peer(id: peer.id)!
         XCTAssertEqual(updated.latitude, 1.0)
         XCTAssertEqual(updated.longitude, 1.0)
         let newPrefix = String(updated.geohash.prefix(5))
         XCTAssertNotEqual(oldPrefix, newPrefix)
-        XCTAssertTrue(manager.peers(inGeohash: newPrefix).contains(updated))
-        XCTAssertFalse(manager.peers(inGeohash: oldPrefix).contains(updated))
+        XCTAssertTrue(await manager.peers(inGeohash: newPrefix).contains(updated))
+        XCTAssertFalse(await manager.peers(inGeohash: oldPrefix).contains(updated))
     }
 
-    func testUpdatingPeerAttributes() {
+    func testUpdatingPeerAttributes() async {
         let manager = PeerManager()
         let peer = try! Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "gaming"])
-        manager.add(peer)
-        manager.updateAttributes(id: peer.id, attributes: ["hobby": "hiking"])
-        let updated = manager.peer(id: peer.id)
+        await manager.add(peer)
+        await manager.updateAttributes(id: peer.id, attributes: ["hobby": "hiking"])
+        let updated = await manager.peer(id: peer.id)
         XCTAssertEqual(updated?.attributes["hobby"], "hiking")
     }
 
-    func testUpdatingSingleAttribute() {
+    func testUpdatingSingleAttribute() async {
         let manager = PeerManager()
         let peer = try! Peer(latitude: 0.0, longitude: 0.0)
-        manager.add(peer)
-        manager.updateAttribute(id: peer.id, key: "hobby", value: "chess")
-        let updated = manager.peer(id: peer.id)
+        await manager.add(peer)
+        await manager.updateAttribute(id: peer.id, key: "hobby", value: "chess")
+        let updated = await manager.peer(id: peer.id)
         XCTAssertEqual(updated?.attributes["hobby"], "chess")
     }
 
-    func testRemovingAttribute() {
+    func testRemovingAttribute() async {
         let manager = PeerManager()
         let peer = try! Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "chess"])
-        manager.add(peer)
-        manager.removeAttribute(id: peer.id, key: "hobby")
-        let updated = manager.peer(id: peer.id)
+        await manager.add(peer)
+        await manager.removeAttribute(id: peer.id, key: "hobby")
+        let updated = await manager.peer(id: peer.id)
         XCTAssertNil(updated?.attributes["hobby"])
     }
 
-    func testUpdatingPeerAddress() {
+    func testUpdatingPeerAddress() async {
         let manager = PeerManager()
         let peer = try! Peer(address: "1.2.3.4", port: 1000, latitude: 0.0, longitude: 0.0)
-        manager.add(peer)
-        manager.updateAddress(id: peer.id, address: "5.6.7.8", port: 2000)
-        let updated = manager.peer(id: peer.id)
+        await manager.add(peer)
+        await manager.updateAddress(id: peer.id, address: "5.6.7.8", port: 2000)
+        let updated = await manager.peer(id: peer.id)
         XCTAssertEqual(updated?.address, "5.6.7.8")
         XCTAssertEqual(updated?.port, 2000)
     }
 
-    func testUpdatingPeerName() {
+    func testUpdatingPeerName() async {
         let manager = PeerManager()
         let peer = try! Peer(name: "Old", latitude: 0.0, longitude: 0.0)
-        manager.add(peer)
-        manager.updateName(id: peer.id, name: "New")
-        let updated = manager.peer(id: peer.id)
+        await manager.add(peer)
+        await manager.updateName(id: peer.id, name: "New")
+        let updated = await manager.peer(id: peer.id)
         XCTAssertEqual(updated?.name, "New")
         XCTAssertNotEqual(updated?.lastSeen, peer.lastSeen)
     }
 
-    func testMatchPeersRanksByAttributeScoreThenDistance() {
+    func testMatchPeersRanksByAttributeScoreThenDistance() async {
         let manager = PeerManager()
         let origin = try! Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "hiking"])
         let nearMatch = try! Peer(latitude: 0.0, longitude: 0.05, attributes: ["hobby": "hiking"])
         let farMatch = try! Peer(latitude: 0.0, longitude: 1.0, attributes: ["hobby": "hiking"])
         let nonMatch = try! Peer(latitude: 0.0, longitude: 0.05, attributes: ["hobby": "gaming"])
 
-        manager.add(nearMatch)
-        manager.add(farMatch)
-        manager.add(nonMatch)
+        await manager.add(nearMatch)
+        await manager.add(farMatch)
+        await manager.add(nonMatch)
 
-        let matches = manager.matchPeers(for: origin, radius: 2000.0, limit: 2)
+        let matches = await manager.matchPeers(for: origin, radius: 2000.0, limit: 2)
         XCTAssertEqual(matches.count, 2)
         XCTAssertEqual(matches[0], nearMatch)
         XCTAssertEqual(matches[1], farMatch)
     }
 
-    func testPrunesStalePeers() {
+    func testPrunesStalePeers() async {
         let manager = PeerManager()
         let fresh = try! Peer(latitude: 0.0, longitude: 0.0)
         let stale = try! Peer(latitude: 0.0, longitude: 0.0, lastSeen: Date(timeIntervalSinceNow: -7200))
-        manager.add(fresh)
-        manager.add(stale)
+        await manager.add(fresh)
+        await manager.add(stale)
 
-        manager.pruneStale(before: Date(timeIntervalSinceNow: -3600))
+        await manager.pruneStale(before: Date(timeIntervalSinceNow: -3600))
 
-        XCTAssertEqual(manager.allPeers(), [fresh])
+        XCTAssertEqual(await manager.allPeers(), [fresh])
     }
 
-    func testPruneStaleRemovesLikedPeers() {
+    func testPruneStaleRemovesLikedPeers() async {
         let manager = PeerManager()
         let fresh = try! Peer(latitude: 0.0, longitude: 0.0)
         let stale = try! Peer(latitude: 0.0, longitude: 0.0, lastSeen: Date(timeIntervalSinceNow: -7200))
-        manager.add(fresh)
-        manager.add(stale)
-        manager.like(id: fresh.id)
-        manager.like(id: stale.id)
+        await manager.add(fresh)
+        await manager.add(stale)
+        await manager.like(id: fresh.id)
+        await manager.like(id: stale.id)
 
-        manager.pruneStale(before: Date(timeIntervalSinceNow: -3600))
+        await manager.pruneStale(before: Date(timeIntervalSinceNow: -3600))
 
-        XCTAssertEqual(manager.likedPeers(), [fresh])
+        XCTAssertEqual(await manager.likedPeers(), [fresh])
     }
 
-    func testUpdateLastSeenChangesTimestamp() {
+    func testUpdateLastSeenChangesTimestamp() async {
         let manager = PeerManager()
         let oldDate = Date(timeIntervalSince1970: 0)
         let peer = try! Peer(latitude: 0.0, longitude: 0.0, lastSeen: oldDate)
-        manager.add(peer)
+        await manager.add(peer)
 
         let newDate = Date(timeIntervalSince1970: 100)
-        manager.updateLastSeen(id: peer.id, at: newDate)
+        await manager.updateLastSeen(id: peer.id, at: newDate)
 
-        let updated = manager.peer(id: peer.id)
+        let updated = await manager.peer(id: peer.id)
         XCTAssertEqual(updated?.lastSeen, newDate)
     }
 
-    func testPersistenceRoundTrip() throws {
+    func testPersistenceRoundTrip() async throws {
         let manager = PeerManager()
         let timestamp = Date(timeIntervalSince1970: 1234)
         let peer = try! Peer(latitude: 1.0, longitude: 2.0, lastSeen: timestamp)
-        manager.add(peer)
+        await manager.add(peer)
 
         let tmp = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
         let store = PeerStore(url: tmp)
-        try manager.save(to: store)
+        try await manager.save(to: store)
 
         let restored = PeerManager()
-        try restored.load(from: store)
-        XCTAssertEqual(restored.allPeers(), [peer])
-        XCTAssertEqual(restored.peer(id: peer.id)?.lastSeen, timestamp)
+        try await restored.load(from: store)
+        XCTAssertEqual(await restored.allPeers(), [peer])
+        XCTAssertEqual(await restored.peer(id: peer.id)?.lastSeen, timestamp)
     }
 
-    func testBlockedPeersPersistThroughStore() throws {
+    func testBlockedPeersPersistThroughStore() async throws {
         let manager = PeerManager()
         let peer = try! Peer(latitude: 0.0, longitude: 0.0)
-        manager.add(peer)
-        manager.block(id: peer.id)
+        await manager.add(peer)
+        await manager.block(id: peer.id)
 
         let tmp = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
         let store = PeerStore(url: tmp)
-        try manager.save(to: store)
+        try await manager.save(to: store)
 
         let restored = PeerManager()
-        try restored.load(from: store)
+        try await restored.load(from: store)
 
-        XCTAssertEqual(restored.allPeers().count, 0)
-        restored.unblock(id: peer.id)
-        XCTAssertEqual(restored.allPeers(), [peer])
+        XCTAssertEqual(await restored.allPeers().count, 0)
+        await restored.unblock(id: peer.id)
+        XCTAssertEqual(await restored.allPeers(), [peer])
     }
 
-    func testLikedPeersAreReturned() {
+    func testLikedPeersAreReturned() async {
         let manager = PeerManager()
         let peer = try! Peer(latitude: 0.0, longitude: 0.0)
-        manager.add(peer)
-        manager.like(id: peer.id)
+        await manager.add(peer)
+        await manager.like(id: peer.id)
 
-        XCTAssertEqual(manager.likedPeers(), [peer])
+        XCTAssertEqual(await manager.likedPeers(), [peer])
 
-        manager.block(id: peer.id)
-        XCTAssertTrue(manager.likedPeers().isEmpty)
+        await manager.block(id: peer.id)
+        XCTAssertTrue(await manager.likedPeers().isEmpty)
     }
 
-    func testLikedPeersPersistThroughStore() throws {
+    func testLikedPeersPersistThroughStore() async throws {
         let manager = PeerManager()
         let peer = try! Peer(latitude: 0.0, longitude: 0.0)
-        manager.add(peer)
-        manager.like(id: peer.id)
+        await manager.add(peer)
+        await manager.like(id: peer.id)
 
         let tmp = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
         let store = PeerStore(url: tmp)
-        try manager.save(to: store)
+        try await manager.save(to: store)
 
         let restored = PeerManager()
-        try restored.load(from: store)
+        try await restored.load(from: store)
 
-        XCTAssertEqual(restored.likedPeers(), [peer])
+        XCTAssertEqual(await restored.likedPeers(), [peer])
     }
 
-    func testMutualLikesReturnPeersWhoLikeUser() {
+    func testMutualLikesReturnPeersWhoLikeUser() async {
         let manager = PeerManager()
         let myID = UUID()
         let liker = try! Peer(latitude: 0.0, longitude: 0.0, attributes: ["likes": myID.uuidString])
         let nonLiker = try! Peer(latitude: 0.0, longitude: 0.0)
-        manager.add(liker)
-        manager.add(nonLiker)
-        manager.like(id: liker.id)
-        manager.like(id: nonLiker.id)
+        await manager.add(liker)
+        await manager.add(nonLiker)
+        await manager.like(id: liker.id)
+        await manager.like(id: nonLiker.id)
 
-        let matches = manager.mutualLikes(for: myID)
+        let matches = await manager.mutualLikes(for: myID)
         XCTAssertEqual(matches, [liker])
     }
 
-    func testBlockedPeersAreExcludedFromQueries() {
+    func testBlockedPeersAreExcludedFromQueries() async {
         let manager = PeerManager()
         let first = try! Peer(latitude: 0.0, longitude: 0.0)
         let second = try! Peer(latitude: 0.0, longitude: 0.0)
-        manager.add(first)
-        manager.add(second)
+        await manager.add(first)
+        await manager.add(second)
 
-        manager.block(id: second.id)
+        await manager.block(id: second.id)
 
-        XCTAssertEqual(manager.allPeers(), [first])
-        XCTAssertFalse(manager.peers(near: 0.0, longitude: 0.0, radius: 1.0).contains(second))
+        XCTAssertEqual(await manager.allPeers(), [first])
+        XCTAssertFalse(await manager.peers(near: 0.0, longitude: 0.0, radius: 1.0).contains(second))
 
-        manager.unblock(id: second.id)
-        let all = manager.allPeers()
+        await manager.unblock(id: second.id)
+        let all = await manager.allPeers()
         XCTAssertTrue(all.contains(first))
         XCTAssertTrue(all.contains(second))
     }
 
-    func testConnectUpdatesLastSeen() {
+    func testConnectUpdatesLastSeen() async {
         let manager = PeerManager()
         let oldDate = Date(timeIntervalSince1970: 0)
         let peer = try! Peer(latitude: 0.0, longitude: 0.0, lastSeen: oldDate)
-        manager.add(peer)
+        await manager.add(peer)
 
-        let success = manager.connect(to: peer.id)
+        let success = await manager.connect(to: peer.id)
         XCTAssertTrue(success)
-        let updated = manager.peer(id: peer.id)
+        let updated = await manager.peer(id: peer.id)
         XCTAssertNotEqual(updated?.lastSeen, oldDate)
     }
 
-    func testConnectFailsForBlockedPeer() {
+    func testConnectFailsForBlockedPeer() async {
         let manager = PeerManager()
         let peer = try! Peer(latitude: 0.0, longitude: 0.0)
-        manager.add(peer)
-        manager.block(id: peer.id)
+        await manager.add(peer)
+        await manager.block(id: peer.id)
 
-        XCTAssertFalse(manager.connect(to: peer.id))
+        XCTAssertFalse(await manager.connect(to: peer.id))
     }
 
-    func testGeohashEncoding() {
+    func testGeohashEncoding() async {
         let sf = try! Peer(latitude: 37.7749, longitude: -122.4194)
         XCTAssertEqual(sf.geohash, "9q8yyk8y")
     }
 
-    func testPeersInGeohashPrefix() {
+    func testPeersInGeohashPrefix() async {
         let manager = PeerManager()
         let sf = try! Peer(latitude: 37.7749, longitude: -122.4194)
         let la = try! Peer(latitude: 34.0522, longitude: -118.2437)
-        manager.add(sf)
-        manager.add(la)
+        await manager.add(sf)
+        await manager.add(la)
 
         let prefix = String(sf.geohash.prefix(5))
-        let results = manager.peers(inGeohash: prefix)
+        let results = await manager.peers(inGeohash: prefix)
         XCTAssertEqual(results, [sf])
     }
 
-    func testPeersInShorterGeohashPrefix() {
+    func testPeersInShorterGeohashPrefix() async {
         let manager = PeerManager()
         let sf = try! Peer(latitude: 37.7749, longitude: -122.4194)
         let la = try! Peer(latitude: 34.0522, longitude: -118.2437)
-        manager.add(sf)
-        manager.add(la)
+        await manager.add(sf)
+        await manager.add(la)
 
         let shortPrefix = String(sf.geohash.prefix(3))
-        let results = manager.peers(inGeohash: shortPrefix)
+        let results = await manager.peers(inGeohash: shortPrefix)
         XCTAssertTrue(results.contains(sf))
         XCTAssertFalse(results.contains(la))
     }
 
-    func testPeersInLongerGeohashPrefix() {
+    func testPeersInLongerGeohashPrefix() async {
         let manager = PeerManager()
         let first = try! Peer(latitude: 37.7749, longitude: -122.4194)
         let second = try! Peer(latitude: 37.7750, longitude: -122.4195)
-        manager.add(first)
-        manager.add(second)
+        await manager.add(first)
+        await manager.add(second)
 
         var prefixLength = 6
         while prefixLength <= first.geohash.count &&
@@ -397,85 +396,76 @@ final class PeerManagerTests: XCTestCase {
         XCTAssertGreaterThan(prefixLength, 5)
 
         let longPrefix = String(first.geohash.prefix(prefixLength))
-        let results = manager.peers(inGeohash: longPrefix)
+        let results = await manager.peers(inGeohash: longPrefix)
         XCTAssertEqual(results, [first])
     }
 
 
-    func testPeersInGeohashPrefixWithAttributeFilter() {
+    func testPeersInGeohashPrefixWithAttributeFilter() async {
         let manager = PeerManager()
         let sfHiker = try! Peer(latitude: 37.7749, longitude: -122.4194, attributes: ["hobby": "hiking"])
         let sfBaker = try! Peer(latitude: 37.7750, longitude: -122.4195, attributes: ["hobby": "baking"])
         let laHiker = try! Peer(latitude: 34.0522, longitude: -118.2437, attributes: ["hobby": "hiking"])
-        manager.add(sfHiker)
-        manager.add(sfBaker)
-        manager.add(laHiker)
+        await manager.add(sfHiker)
+        await manager.add(sfBaker)
+        await manager.add(laHiker)
 
         let prefix = String(sfHiker.geohash.prefix(5))
-        let results = manager.peers(inGeohash: prefix, matching: ["hobby": "hiking"])
+        let results = await manager.peers(inGeohash: prefix, matching: ["hobby": "hiking"])
         XCTAssertEqual(results, [sfHiker])
     }
 
 
-    func testRecentPeersReturnsMostRecentFirst() {
+    func testRecentPeersReturnsMostRecentFirst() async {
         let manager = PeerManager()
         let older = try! Peer(latitude: 0.0, longitude: 0.0, lastSeen: Date(timeIntervalSinceNow: -3600))
         let newer = try! Peer(latitude: 0.0, longitude: 0.0)
         let blocked = try! Peer(latitude: 0.0, longitude: 0.0)
 
-        manager.add(older)
-        manager.add(newer)
-        manager.add(blocked)
-        manager.block(id: blocked.id)
+        await manager.add(older)
+        await manager.add(newer)
+        await manager.add(blocked)
+        await manager.block(id: blocked.id)
 
-        let results = manager.recentPeers(limit: 5)
+        let results = await manager.recentPeers(limit: 5)
         XCTAssertEqual(results, [newer, older])
 
     }
 
     /// Ensures the manager handles concurrent access without crashing or losing peers.
-    func testConcurrentAccess() {
+    func testConcurrentAccess() async {
         let manager = PeerManager()
-        let group = DispatchGroup()
-        let queue = DispatchQueue.global(qos: .default)
 
-        for _ in 0..<100 {
-            group.enter()
-            queue.async {
-                let peer = try! Peer(latitude: 0.0, longitude: 0.0)
-                manager.add(peer)
-                group.leave()
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<100 {
+                group.addTask {
+                    let peer = try! Peer(latitude: 0.0, longitude: 0.0)
+                    await manager.add(peer)
+                }
             }
         }
 
-        group.wait()
-        XCTAssertEqual(manager.allPeers().count, 100)
+        XCTAssertEqual(await manager.allPeers().count, 100)
     }
 
-    /// Invokes `nearestPeers` while other threads mutate the manager to ensure thread safety.
-    func testNearestPeersThreadSafetyDuringMutation() {
+    /// Invokes `nearestPeers` while other tasks mutate the manager to ensure thread safety.
+    func testNearestPeersThreadSafetyDuringMutation() async {
         let manager = PeerManager()
-        let queue = DispatchQueue.global(qos: .default)
-        let group = DispatchGroup()
 
-        for _ in 0..<100 {
-            group.enter()
-            queue.async {
-                let peer = try! Peer(latitude: 0.0, longitude: 0.0)
-                manager.add(peer)
-                group.leave()
-            }
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<100 {
+                group.addTask {
+                    let peer = try! Peer(latitude: 0.0, longitude: 0.0)
+                    await manager.add(peer)
+                }
 
-            group.enter()
-            queue.async {
-                _ = manager.nearestPeers(to: 0.0, longitude: 0.0, limit: 5)
-                group.leave()
+                group.addTask {
+                    _ = await manager.nearestPeers(to: 0.0, longitude: 0.0, limit: 5)
+                }
             }
         }
 
-        group.wait()
-
-        XCTAssertEqual(manager.allPeers().count, 100)
-        XCTAssertLessThanOrEqual(manager.nearestPeers(to: 0.0, longitude: 0.0, limit: 5).count, 5)
+        XCTAssertEqual(await manager.allPeers().count, 100)
+        XCTAssertLessThanOrEqual(await manager.nearestPeers(to: 0.0, longitude: 0.0, limit: 5).count, 5)
     }
 }


### PR DESCRIPTION
## Summary
- Convert `PeerManager` from a class using `DispatchQueue` to an `actor` with actor isolation
- Update usage, including demo and tests, to await `PeerManager` APIs
- Modernize concurrency tests using Swift's structured concurrency

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/libp2p/swift-libp2p.git)*

------
https://chatgpt.com/codex/tasks/task_e_688fbf2756ec832ba66d3ac424a765c8