### PR TITLE
Fix peer geohash reindexing on re-add

### DIFF
--- a/Sources/PeerManager.swift
+++ b/Sources/PeerManager.swift
@@ -47,6 +47,17 @@ actor PeerManager {
 
     /// Adds or updates a peer in the manager.
     func add(_ peer: Peer) {
+        if let existing = peerIndex[peer.id] {
+            let oldKey = existing.geohash
+            if var bucket = geohashIndex[oldKey] {
+                bucket.remove(peer.id)
+                if bucket.isEmpty {
+                    geohashIndex.removeValue(forKey: oldKey)
+                } else {
+                    geohashIndex[oldKey] = bucket
+                }
+            }
+        }
         peerIndex[peer.id] = peer
         let key = peer.geohash
         var bucket = geohashIndex[key] ?? Set<UUID>()

--- a/Tests/WeaveTests/PeerManagerTests.swift
+++ b/Tests/WeaveTests/PeerManagerTests.swift
@@ -469,4 +469,19 @@ final class PeerManagerTests: XCTestCase {
         XCTAssertEqual(await manager.allPeers().count, 100)
         XCTAssertLessThanOrEqual(await manager.nearestPeers(to: 0.0, longitude: 0.0, limit: 5).count, 5)
     }
+
+    func testReaddingPeerReindexesGeohash() async {
+        let manager = PeerManager()
+        let id = UUID()
+        let first = try! Peer(id: id, latitude: 37.0, longitude: -122.0)
+        await manager.add(first)
+        let oldHash = first.geohash
+
+        let second = try! Peer(id: id, latitude: 40.0, longitude: -74.0)
+        await manager.add(second)
+        let newHash = second.geohash
+
+        XCTAssertTrue(await manager.peers(inGeohash: oldHash).isEmpty)
+        XCTAssertEqual(await manager.peers(inGeohash: newHash), [second])
+    }
 }


### PR DESCRIPTION
## Summary
- ensure PeerManager removes old geohash index before re-adding a peer
- add test verifying geohash index is updated when re-adding

## Testing
- `swift test` *(fails: unable to access 'https://github.com/libp2p/swift-libp2p.git/' due to 403)*

------
https://chatgpt.com/codex/tasks/task_e_688fc3e4f798832bbe443e0772740add