### PR TITLE
Ensure LocationService cleans up on deinit

### DIFF
--- a/Sources/LocationService.swift
+++ b/Sources/LocationService.swift
@@ -13,6 +13,7 @@ protocol LocationServiceDelegate: AnyObject {
 /// callback.
 final class LocationService: NSObject, CLLocationManagerDelegate {
     private let manager = CLLocationManager()
+    private var didStop = false
 
     /// Delegate that receives location updates.
     weak var delegate: LocationServiceDelegate?
@@ -42,6 +43,8 @@ final class LocationService: NSObject, CLLocationManagerDelegate {
 
     /// Stops location updates and clears callbacks.
     func stop() {
+        guard !didStop else { return }
+        didStop = true
         manager.stopUpdatingLocation()
         manager.delegate = nil
         delegate = nil
@@ -68,6 +71,10 @@ final class LocationService: NSObject, CLLocationManagerDelegate {
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
         delegate?.locationService(self, didFailWithError: error)
         onError?(error)
+    }
+
+    deinit {
+        stop()
     }
 }
 #endif

--- a/Tests/WeaveTests/LocationServiceTests.swift
+++ b/Tests/WeaveTests/LocationServiceTests.swift
@@ -78,5 +78,19 @@ final class LocationServiceTests: XCTestCase {
         XCTAssertNil(service.onLocationUpdate)
         XCTAssertNil(service.onError)
     }
+
+    func testDeinitClearsManagerDelegate() {
+        var service: LocationService? = LocationService()
+
+        let mirror = Mirror(reflecting: service as Any)
+        guard let manager = mirror.children.first(where: { $0.label == "manager" })?.value as? CLLocationManager else {
+            XCTFail("Unable to access CLLocationManager")
+            return
+        }
+
+        XCTAssertNotNil(manager.delegate)
+        service = nil
+        XCTAssertNil(manager.delegate)
+    }
 }
 #endif


### PR DESCRIPTION
## Summary
- make `LocationService.stop()` idempotent and automatically invoked from `deinit`
- add unit test verifying `CLLocationManager` delegate clears when `LocationService` is deallocated

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/libp2p/swift-libp2p.git: fatal: unable to access 'https://github.com/libp2p/swift-libp2p.git/': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688fc3e5aa98832baed47a26ac7caec5