### PR TITLE
feat: add Hashable conformance to Peer

### DIFF
--- a/Sources/Peer.swift
+++ b/Sources/Peer.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Represents a peer in the Weave network.
 /// Peers are identified by a unique ID and may advertise
 /// a network address and their geographic location.
-struct Peer: Identifiable, Codable, Equatable {
+struct Peer: Identifiable, Codable, Equatable, Hashable {
     enum PeerError: Error {
         case invalidLatitude(Double)
         case invalidLongitude(Double)
@@ -113,5 +113,17 @@ struct Peer: Identifiable, Codable, Equatable {
         lhs.attributes == rhs.attributes &&
         lhs.lastSeen == rhs.lastSeen
 
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(name)
+        hasher.combine(address)
+        hasher.combine(port)
+        hasher.combine(publicKey)
+        hasher.combine(latitude)
+        hasher.combine(longitude)
+        hasher.combine(attributes)
+        hasher.combine(lastSeen)
     }
 }

--- a/Tests/WeaveTests/PeerTests.swift
+++ b/Tests/WeaveTests/PeerTests.swift
@@ -25,5 +25,36 @@ final class PeerTests: XCTestCase {
         let first = try Peer(id: baseID, latitude: 0, longitude: 0, lastSeen: Date(timeIntervalSince1970: 0))
         let second = try Peer(id: baseID, latitude: 0, longitude: 0, lastSeen: Date(timeIntervalSince1970: 10))
         XCTAssertNotEqual(first, second)
+
+        var set: Set<Peer> = [first, second]
+        XCTAssertEqual(set.count, 2)
+    }
+
+    func testPeersWithIdenticalDataCollapseInSet() throws {
+        let id = UUID()
+        let timestamp = Date(timeIntervalSince1970: 0)
+        let attrs = ["key": "value"]
+        let keyData = Data([0x01, 0x02])
+        let first = try Peer(id: id,
+                             name: "Alice",
+                             address: "1.2.3.4",
+                             port: 8080,
+                             publicKey: keyData,
+                             latitude: 0,
+                             longitude: 0,
+                             attributes: attrs,
+                             lastSeen: timestamp)
+        let duplicate = try Peer(id: id,
+                                 name: "Alice",
+                                 address: "1.2.3.4",
+                                 port: 8080,
+                                 publicKey: keyData,
+                                 latitude: 0,
+                                 longitude: 0,
+                                 attributes: attrs,
+                                 lastSeen: timestamp)
+        var set: Set<Peer> = [first]
+        set.insert(duplicate)
+        XCTAssertEqual(set.count, 1)
     }
 }


### PR DESCRIPTION
## Summary
- make `Peer` conform to `Hashable` and implement custom `hash(into:)`
- add tests ensuring peers behave correctly when stored in `Set`

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688fc3e6d584832b9ba1b183bbe52202