### PR TITLE
Add GeoHash invalid character decoding test

### DIFF
--- a/Tests/WeaveTests/GeoHashTests.swift
+++ b/Tests/WeaveTests/GeoHashTests.swift
@@ -33,6 +33,16 @@ final class GeoHashTests: XCTestCase {
 
     }
 
+    func testDecodeThrowsInvalidCharacter() {
+        let invalidHash = "zzzzzz!z"
+        XCTAssertThrowsError(try GeoHash.decode(invalidHash)) { error in
+            guard case GeoHashError.invalidCharacter(let character) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(character, "!")
+        }
+    }
+
     private func errorForPrecision(_ precision: Int) -> (Double, Double) {
         var latBits = 0
         var lonBits = 0


### PR DESCRIPTION
## Summary
- test decoding invalid GeoHash character raises `GeoHashError.invalidCharacter`

## Testing
- `swift test` *(fails: unable to clone https://github.com/libp2p/swift-libp2p.git)*

------
https://chatgpt.com/codex/tasks/task_e_688fc3e827d8832b991cf2678249782a