### PR TITLE
Add libp2p stream messaging

### DIFF
--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -5,6 +5,16 @@ import Crypto
 import LibP2P
 #endif
 
+/// A bidirectional libp2p stream.
+protocol LibP2PStream {
+    /// The peer this stream is connected to.
+    var peer: Peer { get }
+    /// Send raw bytes over the stream.
+    func write(_ data: Data)
+    /// Register a callback for inbound bytes.
+    func setDataHandler(_ handler: @escaping (Data) -> Void)
+}
+
 /// Abstraction over the underlying libp2p host so it can be mocked in tests.
 protocol LibP2PHosting {
     /// Start listening for connections and initialise any required services.
@@ -15,6 +25,10 @@ protocol LibP2PHosting {
     func enableNAT()
     /// Shut down the host and release any resources.
     func stop()
+    /// Open a new stream to the given peer.
+    func openStream(to peer: Peer) -> LibP2PStream
+    /// Set a handler for incoming streams initiated by remote peers.
+    func setStreamHandler(_ handler: @escaping (LibP2PStream) -> Void)
 }
 
 /// Default no-op implementation used until a real libp2p host is wired in.
@@ -23,6 +37,14 @@ struct NoopLibP2PHost: LibP2PHosting {
     func bootstrap(peers: [String]) {}
     func enableNAT() {}
     func stop() {}
+    func openStream(to peer: Peer) -> LibP2PStream { NoopLibP2PStream(peer: peer) }
+    func setStreamHandler(_ handler: @escaping (LibP2PStream) -> Void) {}
+}
+
+struct NoopLibP2PStream: LibP2PStream {
+    let peer: Peer
+    func write(_ data: Data) {}
+    func setDataHandler(_ handler: @escaping (Data) -> Void) {}
 }
 
 /// A networking node backed by a libp2p host.
@@ -56,6 +78,9 @@ actor P2PNode {
     /// derivation calls.
     private let keyDerivation: (Curve25519.KeyAgreement.PrivateKey, Data) throws -> SymmetricKey
 
+    /// Handler invoked for decrypted inbound messages.
+    private var messageHandler: (@Sendable (Data, Peer) -> Void)?
+
     init(bootstrapPeers: [String] = [],
 
          hostBuilder: @escaping () -> LibP2PHosting = { NoopLibP2PHost() },
@@ -77,7 +102,9 @@ actor P2PNode {
 
         let host = hostBuilder()
         self.host = host
-
+        host.setStreamHandler { stream in
+            Task { await self.handleIncoming(stream: stream) }
+        }
         host.start()
         if !bootstrapPeers.isEmpty {
             host.bootstrap(peers: bootstrapPeers)
@@ -93,6 +120,22 @@ actor P2PNode {
         host?.stop()
         host = nil
         isRunning = false
+    }
+
+    /// Register a callback to receive decrypted messages from peers.
+    func setMessageHandler(_ handler: @escaping @Sendable (Data, Peer) -> Void) {
+        messageHandler = handler
+    }
+
+    /// Opens a new libp2p stream to the given peer.
+    func openStream(to peer: Peer) -> LibP2PStream? {
+        host?.openStream(to: peer)
+    }
+
+    /// Encrypts and sends a message over an existing stream.
+    func sendMessage(_ message: Data, over stream: LibP2PStream) throws {
+        let encrypted = try send(message, to: stream.peer)
+        stream.write(encrypted)
     }
 
     /// Encrypts `message` for the given peer using a shared secret.
@@ -151,6 +194,21 @@ actor P2PNode {
 
     enum P2PError: Error {
         case missingPeerPublicKey
+    }
+
+    /// Handles a newly opened incoming stream.
+    private func handleIncoming(stream: LibP2PStream) {
+        stream.setDataHandler { data in
+            Task { await self.handleIncomingData(data, from: stream.peer) }
+        }
+    }
+
+    /// Decrypts data from a peer and forwards it to the registered handler.
+    private func handleIncomingData(_ data: Data, from peer: Peer) {
+        guard let handler = messageHandler else { return }
+        if let decrypted = try? receive(data, from: peer) {
+            handler(decrypted, peer)
+        }
     }
 }
 

--- a/Tests/WeaveTests/P2PNodeTests.swift
+++ b/Tests/WeaveTests/P2PNodeTests.swift
@@ -13,6 +13,8 @@ final class P2PNodeTests: XCTestCase {
         func bootstrap(peers: [String]) { bootstrapped = peers }
         func enableNAT() { natEnabled = true }
         func stop() { stopCount += 1 }
+        func openStream(to peer: Peer) -> LibP2PStream { NoopLibP2PStream(peer: peer) }
+        func setStreamHandler(_ handler: @escaping (LibP2PStream) -> Void) {}
     }
 
     func testStartBootstrapsAndEnablesNAT() async {
@@ -122,5 +124,88 @@ final class P2PNodeTests: XCTestCase {
         // peers[0] should still be cached
         _ = try node.send(message, to: peers[0])
         XCTAssertEqual(derivationCalls, 102)
+    }
+
+    // MARK: - Stream based messaging
+
+    /// Mock stream used for simulating libp2p streams in tests.
+    final class MockStream: LibP2PStream {
+        let peer: Peer
+        var dataHandler: ((Data) -> Void)?
+        weak var remote: MockStream?
+
+        init(peer: Peer) { self.peer = peer }
+
+        func write(_ data: Data) { remote?.dataHandler?(data) }
+        func setDataHandler(_ handler: @escaping (Data) -> Void) { dataHandler = handler }
+    }
+
+    /// Mock host capable of opening streams to connected peers.
+    final class StreamHost: LibP2PHosting {
+        let selfPeer: Peer
+        var peers: [UUID: (host: StreamHost, peer: Peer)] = [:]
+        var handler: ((LibP2PStream) -> Void)?
+
+        init(selfPeer: Peer) { self.selfPeer = selfPeer }
+
+        func connect(to host: StreamHost, as peer: Peer) { peers[peer.id] = (host, peer) }
+
+        func start() {}
+        func bootstrap(peers: [String]) {}
+        func enableNAT() {}
+        func stop() {}
+
+        func openStream(to peer: Peer) -> LibP2PStream {
+            let local = MockStream(peer: peer)
+            if let (remoteHost, _) = peers[peer.id] {
+                let remote = MockStream(peer: self.selfPeer)
+                local.remote = remote
+                remote.remote = local
+                remoteHost.handler?(remote)
+            }
+            return local
+        }
+
+        func setStreamHandler(_ handler: @escaping (LibP2PStream) -> Void) { self.handler = handler }
+    }
+
+    func testRoundTripMessageBetweenTwoNodes() async throws {
+        let keysA = Encryption.generateKeyPair()
+        let peerA = try Peer(publicKey: keysA.publicKey, latitude: 0, longitude: 0)
+        let keysB = Encryption.generateKeyPair()
+        let peerB = try Peer(publicKey: keysB.publicKey, latitude: 0, longitude: 0)
+
+        let hostA = StreamHost(selfPeer: peerA)
+        let hostB = StreamHost(selfPeer: peerB)
+        hostA.connect(to: hostB, as: peerB)
+        hostB.connect(to: hostA, as: peerA)
+
+        let nodeA = P2PNode(hostBuilder: { hostA })
+        let nodeB = P2PNode(hostBuilder: { hostB })
+
+        let expA = expectation(description: "NodeA received")
+        let expB = expectation(description: "NodeB received")
+
+        await nodeA.setMessageHandler { data, peer in
+            XCTAssertEqual(String(decoding: data, as: UTF8.self), "pong")
+            XCTAssertEqual(peer.id, peerB.id)
+            expA.fulfill()
+        }
+        await nodeB.setMessageHandler { data, peer in
+            XCTAssertEqual(String(decoding: data, as: UTF8.self), "ping")
+            XCTAssertEqual(peer.id, peerA.id)
+            expB.fulfill()
+        }
+
+        await nodeA.start()
+        await nodeB.start()
+
+        let streamAB = await nodeA.openStream(to: peerB)!
+        try await nodeA.sendMessage(Data("ping".utf8), over: streamAB)
+        await fulfillment(of: [expB], timeout: 1.0)
+
+        let streamBA = await nodeB.openStream(to: peerA)!
+        try await nodeB.sendMessage(Data("pong".utf8), over: streamBA)
+        await fulfillment(of: [expA], timeout: 1.0)
     }
 }


### PR DESCRIPTION
## Summary
- introduce libp2p stream protocol and host callbacks
- allow P2PNode to open streams, send encrypted messages and handle inbound data
- add round-trip messaging test using mock hosts and streams

## Testing
- `swift test 2>&1 | head -n 200` *(fails: unable to access 'https://github.com/libp2p/swift-libp2p.git', CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68900991817c832b96dd3f683ca48f0f