### PR TITLE
Enable bidirectional libp2p streams

### DIFF
--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -42,6 +42,49 @@ struct LibP2PHost: LibP2PHosting {
     func stop() {
         _ = try? host.stop().wait()
     }
+
+    /// Open a new stream to the given peer.
+    func openStream(to peer: Peer) -> LibP2PStream {
+        // Construct a multiaddr from the peer's address and port. If either is
+        // missing, this will trap which is acceptable for now as the caller is
+        // expected to provide fully resolved peers when opening streams.
+        let addr = try! Multiaddr("/ip4/\(peer.address!)/tcp/\(peer.port!)")
+        let stream = try! host.openStream(to: addr).wait()
+        return HostStream(peer: peer, stream: stream)
+    }
+
+    /// Register a handler for incoming streams initiated by remote peers.
+    func setStreamHandler(_ handler: @escaping (LibP2PStream) -> Void) {
+        host.setStreamHandler { stream in
+            // Derive a minimal `Peer` representation from the remote
+            // connection. The remote address is extracted if available, but any
+            // location information is left at defaults.
+            let remoteAddr = stream.connection.remoteAddress
+            let ip = remoteAddr.ipAddress ?? "0.0.0.0"
+            let port = UInt16(remoteAddr.port ?? 0)
+            let peer = try! Peer(address: ip, port: port, latitude: 0, longitude: 0)
+            handler(HostStream(peer: peer, stream: stream))
+        }
+    }
+}
+
+/// Wrapper around libp2p's `Stream` type to conform to `LibP2PStream`.
+private final class HostStream: LibP2PStream {
+    let peer: Peer
+    private let stream: Stream
+
+    init(peer: Peer, stream: Stream) {
+        self.peer = peer
+        self.stream = stream
+    }
+
+    func write(_ data: Data) {
+        _ = try? stream.write(data).wait()
+    }
+
+    func setDataHandler(_ handler: @escaping (Data) -> Void) {
+        stream.setDataHandler(handler)
+    }
 }
 #endif
 
@@ -118,8 +161,9 @@ actor P2PNode {
     /// derivation calls.
     private let keyDerivation: (Curve25519.KeyAgreement.PrivateKey, Data) throws -> SymmetricKey
 
-    /// Handler invoked for decrypted inbound messages.
-    private var messageHandler: (@Sendable (Data, Peer) -> Void)?
+    /// Handler invoked for decrypted inbound messages. The associated stream is
+    /// provided so callers can respond over the same channel if desired.
+    private var messageHandler: (@Sendable (Data, Peer, LibP2PStream) -> Void)?
 
     init(bootstrapPeers: [String] = [],
          hostBuilder: @escaping () -> LibP2PHosting = {
@@ -168,13 +212,17 @@ actor P2PNode {
     }
 
     /// Register a callback to receive decrypted messages from peers.
-    func setMessageHandler(_ handler: @escaping @Sendable (Data, Peer) -> Void) {
+    func setMessageHandler(_ handler: @escaping @Sendable (Data, Peer, LibP2PStream) -> Void) {
         messageHandler = handler
     }
 
     /// Opens a new libp2p stream to the given peer.
     func openStream(to peer: Peer) -> LibP2PStream? {
-        host?.openStream(to: peer)
+        guard let stream = host?.openStream(to: peer) else { return nil }
+        stream.setDataHandler { data in
+            Task { await self.handleIncomingData(data, over: stream) }
+        }
+        return stream
     }
 
     /// Encrypts and sends a message over an existing stream.
@@ -244,15 +292,16 @@ actor P2PNode {
     /// Handles a newly opened incoming stream.
     private func handleIncoming(stream: LibP2PStream) {
         stream.setDataHandler { data in
-            Task { await self.handleIncomingData(data, from: stream.peer) }
+            Task { await self.handleIncomingData(data, over: stream) }
         }
     }
 
     /// Decrypts data from a peer and forwards it to the registered handler.
-    private func handleIncomingData(_ data: Data, from peer: Peer) {
+    private func handleIncomingData(_ data: Data, over stream: LibP2PStream) {
         guard let handler = messageHandler else { return }
+        let peer = stream.peer
         if let decrypted = try? receive(data, from: peer) {
-            handler(decrypted, peer)
+            handler(decrypted, peer, stream)
         }
     }
 }

--- a/Tests/WeaveTests/P2PNodeTests.swift
+++ b/Tests/WeaveTests/P2PNodeTests.swift
@@ -169,7 +169,7 @@ final class P2PNodeTests: XCTestCase {
         func setStreamHandler(_ handler: @escaping (LibP2PStream) -> Void) { self.handler = handler }
     }
 
-    func testRoundTripMessageBetweenTwoNodes() async throws {
+    func testStreamDeliversDataBothWays() async throws {
         let keysA = Encryption.generateKeyPair()
         let peerA = try Peer(publicKey: keysA.publicKey, latitude: 0, longitude: 0)
         let keysB = Encryption.generateKeyPair()
@@ -183,17 +183,18 @@ final class P2PNodeTests: XCTestCase {
         let nodeA = P2PNode(hostBuilder: { hostA })
         let nodeB = P2PNode(hostBuilder: { hostB })
 
-        let expA = expectation(description: "NodeA received")
-        let expB = expectation(description: "NodeB received")
+        let expA = expectation(description: "NodeA received pong")
+        let expB = expectation(description: "NodeB received ping")
 
-        await nodeA.setMessageHandler { data, peer in
+        await nodeA.setMessageHandler { data, peer, _ in
             XCTAssertEqual(String(decoding: data, as: UTF8.self), "pong")
             XCTAssertEqual(peer.id, peerB.id)
             expA.fulfill()
         }
-        await nodeB.setMessageHandler { data, peer in
+        await nodeB.setMessageHandler { data, peer, stream in
             XCTAssertEqual(String(decoding: data, as: UTF8.self), "ping")
             XCTAssertEqual(peer.id, peerA.id)
+            Task { try? await nodeB.sendMessage(Data("pong".utf8), over: stream) }
             expB.fulfill()
         }
 
@@ -202,10 +203,7 @@ final class P2PNodeTests: XCTestCase {
 
         let streamAB = await nodeA.openStream(to: peerB)!
         try await nodeA.sendMessage(Data("ping".utf8), over: streamAB)
-        await fulfillment(of: [expB], timeout: 1.0)
 
-        let streamBA = await nodeB.openStream(to: peerA)!
-        try await nodeB.sendMessage(Data("pong".utf8), over: streamBA)
-        await fulfillment(of: [expA], timeout: 1.0)
+        await fulfillment(of: [expB, expA], timeout: 1.0)
     }
 }


### PR DESCRIPTION
## Summary
- add real `LibP2PHost` stream handling using host APIs
- allow `P2PNode` message handlers to respond over the originating stream
- test that a single stream carries data in both directions

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68900ca0a390832b82481caf55fae409