### PR TITLE
Encode messages in P2PNode

### DIFF
--- a/Sources/Message.swift
+++ b/Sources/Message.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct Message: Codable, Equatable {
+    let type: String
+    let payload: Data
+    let metadata: [String: String]?
+}

--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -119,7 +119,7 @@ actor P2PNode {
     private let keyDerivation: (Curve25519.KeyAgreement.PrivateKey, Data) throws -> SymmetricKey
 
     /// Handler invoked for decrypted inbound messages.
-    private var messageHandler: (@Sendable (Data, Peer) -> Void)?
+    private var messageHandler: (@Sendable (Message, Peer) -> Void)?
 
     init(bootstrapPeers: [String] = [],
          hostBuilder: @escaping () -> LibP2PHosting = {
@@ -168,7 +168,7 @@ actor P2PNode {
     }
 
     /// Register a callback to receive decrypted messages from peers.
-    func setMessageHandler(_ handler: @escaping @Sendable (Data, Peer) -> Void) {
+    func setMessageHandler(_ handler: @escaping @Sendable (Message, Peer) -> Void) {
         messageHandler = handler
     }
 
@@ -177,9 +177,10 @@ actor P2PNode {
         host?.openStream(to: peer)
     }
 
-    /// Encrypts and sends a message over an existing stream.
-    func sendMessage(_ message: Data, over stream: LibP2PStream) throws {
-        let encrypted = try send(message, to: stream.peer)
+    /// Encodes, encrypts and sends a message over an existing stream.
+    func sendMessage(_ message: Message, over stream: LibP2PStream) throws {
+        let data = try JSONEncoder().encode(message)
+        let encrypted = try send(data, to: stream.peer)
         stream.write(encrypted)
     }
 
@@ -248,11 +249,12 @@ actor P2PNode {
         }
     }
 
-    /// Decrypts data from a peer and forwards it to the registered handler.
+    /// Decrypts data from a peer, decodes it to a `Message` and forwards it to the registered handler.
     private func handleIncomingData(_ data: Data, from peer: Peer) {
         guard let handler = messageHandler else { return }
-        if let decrypted = try? receive(data, from: peer) {
-            handler(decrypted, peer)
+        if let decrypted = try? receive(data, from: peer),
+           let message = try? JSONDecoder().decode(Message.self, from: decrypted) {
+            handler(message, peer)
         }
     }
 }

--- a/Tests/WeaveTests/P2PNodeTests.swift
+++ b/Tests/WeaveTests/P2PNodeTests.swift
@@ -186,13 +186,15 @@ final class P2PNodeTests: XCTestCase {
         let expA = expectation(description: "NodeA received")
         let expB = expectation(description: "NodeB received")
 
-        await nodeA.setMessageHandler { data, peer in
-            XCTAssertEqual(String(decoding: data, as: UTF8.self), "pong")
+        await nodeA.setMessageHandler { message, peer in
+            XCTAssertEqual(message.type, "pong")
+            XCTAssertEqual(String(decoding: message.payload, as: UTF8.self), "pong")
             XCTAssertEqual(peer.id, peerB.id)
             expA.fulfill()
         }
-        await nodeB.setMessageHandler { data, peer in
-            XCTAssertEqual(String(decoding: data, as: UTF8.self), "ping")
+        await nodeB.setMessageHandler { message, peer in
+            XCTAssertEqual(message.type, "ping")
+            XCTAssertEqual(String(decoding: message.payload, as: UTF8.self), "ping")
             XCTAssertEqual(peer.id, peerA.id)
             expB.fulfill()
         }
@@ -201,11 +203,13 @@ final class P2PNodeTests: XCTestCase {
         await nodeB.start()
 
         let streamAB = await nodeA.openStream(to: peerB)!
-        try await nodeA.sendMessage(Data("ping".utf8), over: streamAB)
+        let ping = Message(type: "ping", payload: Data("ping".utf8), metadata: nil)
+        try await nodeA.sendMessage(ping, over: streamAB)
         await fulfillment(of: [expB], timeout: 1.0)
 
         let streamBA = await nodeB.openStream(to: peerA)!
-        try await nodeB.sendMessage(Data("pong".utf8), over: streamBA)
+        let pong = Message(type: "pong", payload: Data("pong".utf8), metadata: nil)
+        try await nodeB.sendMessage(pong, over: streamBA)
         await fulfillment(of: [expA], timeout: 1.0)
     }
 }


### PR DESCRIPTION
## Summary
- introduce a Codable `Message` type for typed payloads and optional metadata
- send and receive `Message` instances in `P2PNode` rather than raw `Data`
- adjust tests to verify round-trip message types

## Testing
- `swift test` *(fails: unable to clone https://github.com/libp2p/swift-libp2p.git, CONNECT tunnel failed response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68900ca17850832b9833ad0163367001