### PR TITLE
Integrate LocationService into main and add tests

### DIFF
--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -15,6 +15,19 @@ struct Main {
         let selfLon = -122.4194
 
         let me = try! Peer(name: "Me", latitude: selfLat, longitude: selfLon, attributes: ["hobby": "hiking"])
+        await manager.add(me)
+
+#if canImport(CoreLocation)
+        // Track the device's location and feed updates into the peer manager
+        let locationService = LocationService()
+        locationService.onLocationUpdate = { lat, lon in
+            Task {
+                await manager.updateLocation(id: me.id, latitude: lat, longitude: lon)
+            }
+        }
+        locationService.start()
+        defer { locationService.stop() }
+#endif
 
         // Add a peer in San Francisco
         let movingPeer = try! Peer(name: "Alice", latitude: 37.7750, longitude: -122.4183, attributes: ["hobby": "hiking", "likes": me.id.uuidString])

--- a/Tests/WeaveTests/LocationIntegrationTests.swift
+++ b/Tests/WeaveTests/LocationIntegrationTests.swift
@@ -1,0 +1,34 @@
+#if canImport(CoreLocation)
+import XCTest
+import CoreLocation
+@testable import weave
+
+final class LocationIntegrationTests: XCTestCase {
+    func testLocationUpdatesModifyPeerCoordinates() async throws {
+        let expectation = expectation(description: "location update")
+        let manager = PeerManager()
+        let peer = try Peer(latitude: 0.0, longitude: 0.0)
+        await manager.add(peer)
+
+        let service = LocationService()
+        service.onLocationUpdate = { lat, lon in
+            Task {
+                await manager.updateLocation(id: peer.id, latitude: lat, longitude: lon)
+                expectation.fulfill()
+            }
+        }
+
+        service.start()
+
+        let simulated = CLLocation(latitude: 10.0, longitude: 20.0)
+        service.locationManager(CLLocationManager(), didUpdateLocations: [simulated])
+
+        waitForExpectations(timeout: 1.0)
+        let updated = await manager.peer(id: peer.id)
+        XCTAssertEqual(updated?.latitude, 10.0)
+        XCTAssertEqual(updated?.longitude, 20.0)
+
+        service.stop()
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Tie LocationService into the executable, feeding device coordinates to PeerManager and handling lifecycle start/stop.
- Add integration test ensuring location updates propagate into stored peer records.

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68900ca2b3e8832bb7a01d101d5ec8cb