### PR TITLE
Add tests for in-memory DHT

### DIFF
--- a/Tests/WeaveTests/DHTTests.swift
+++ b/Tests/WeaveTests/DHTTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+import Foundation
+@testable import weave
+
+final class DHTTests: XCTestCase {
+    func testLookupReturnsIDsForMatchingPrefixes() async {
+        let dht = InMemoryDHT()
+        let id1 = UUID()
+        let id2 = UUID()
+        let id3 = UUID()
+        await dht.store(peerID: id1, geohash: "abcd123")
+        await dht.store(peerID: id2, geohash: "abef456")
+        await dht.store(peerID: id3, geohash: "xyz789")
+        let abResults = await dht.lookup(prefix: "ab")
+        XCTAssertEqual(Set(abResults), Set([id1, id2]))
+        let abcResults = await dht.lookup(prefix: "abc")
+        XCTAssertEqual(abcResults, [id1])
+        XCTAssertTrue(await dht.lookup(prefix: "nope").isEmpty)
+    }
+
+    func testRemoveDeletesIDsAndEmptiesBuckets() async {
+        let dht = InMemoryDHT()
+        let id1 = UUID()
+        let id2 = UUID()
+        await dht.store(peerID: id1, geohash: "foo")
+        await dht.store(peerID: id2, geohash: "foo")
+        await dht.remove(peerID: id1, geohash: "foo")
+        XCTAssertEqual(await dht.lookup(prefix: "foo"), [id2])
+        await dht.remove(peerID: id2, geohash: "foo")
+        XCTAssertTrue(await dht.lookup(prefix: "foo").isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- add DHTTests covering lookup by prefix and removal of IDs

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68901014b8ac832bbc659d6b911ec942