### PR TITLE
Handle LibP2P failures gracefully

### DIFF
--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -9,11 +9,11 @@ struct LibP2PHost: LibP2PHosting {
     /// Underlying libp2p host instance.
     private let host: Host
 
-    init() {
+    init() throws {
         // Build a default host using libp2p's builder which configures
         // transports, muxers and security implementations suitable for most
         // use cases.
-        self.host = try! HostBuilder().build()
+        self.host = try HostBuilder().build()
     }
 
     /// Start listening for connections.
@@ -43,13 +43,20 @@ struct LibP2PHost: LibP2PHosting {
         _ = try? host.stop().wait()
     }
 
+    enum HostError: Error {
+        case missingPeerAddress
+    }
+
     /// Open a new stream to the given peer.
-    func openStream(to peer: Peer) -> LibP2PStream {
-        // Construct a multiaddr from the peer's address and port. If either is
-        // missing, this will trap which is acceptable for now as the caller is
-        // expected to provide fully resolved peers when opening streams.
-        let addr = try! Multiaddr("/ip4/\(peer.address!)/tcp/\(peer.port!)")
-        let stream = try! host.openStream(to: addr).wait()
+    func openStream(to peer: Peer) throws -> LibP2PStream {
+        // Construct a multiaddr from the peer's address and port. Throw if
+        // either is missing as callers are expected to provide fully resolved
+        // peers when opening streams.
+        guard let address = peer.address, let port = peer.port else {
+            throw HostError.missingPeerAddress
+        }
+        let addr = try Multiaddr("/ip4/\(address)/tcp/\(port)")
+        let stream = try host.openStream(to: addr).wait()
         return HostStream(peer: peer, stream: stream)
     }
 
@@ -62,8 +69,9 @@ struct LibP2PHost: LibP2PHosting {
             let remoteAddr = stream.connection.remoteAddress
             let ip = remoteAddr.ipAddress ?? "0.0.0.0"
             let port = UInt16(remoteAddr.port ?? 0)
-            let peer = try! Peer(address: ip, port: port, latitude: 0, longitude: 0)
-            handler(HostStream(peer: peer, stream: stream))
+            if let peer = try? Peer(address: ip, port: port, latitude: 0, longitude: 0) {
+                handler(HostStream(peer: peer, stream: stream))
+            }
         }
     }
 }
@@ -109,7 +117,7 @@ protocol LibP2PHosting {
     /// Shut down the host and release any resources.
     func stop()
     /// Open a new stream to the given peer.
-    func openStream(to peer: Peer) -> LibP2PStream
+    func openStream(to peer: Peer) throws -> LibP2PStream
     /// Set a handler for incoming streams initiated by remote peers.
     func setStreamHandler(_ handler: @escaping (LibP2PStream) -> Void)
 }
@@ -120,7 +128,7 @@ struct NoopLibP2PHost: LibP2PHosting {
     func bootstrap(peers: [String]) {}
     func enableNAT() {}
     func stop() {}
-    func openStream(to peer: Peer) -> LibP2PStream { NoopLibP2PStream(peer: peer) }
+    func openStream(to peer: Peer) throws -> LibP2PStream { NoopLibP2PStream(peer: peer) }
     func setStreamHandler(_ handler: @escaping (LibP2PStream) -> Void) {}
 }
 
@@ -137,7 +145,7 @@ actor P2PNode {
     /// Addresses of peers used to join the wider network.
     private let bootstrapPeers: [String]
     /// Factory used to create the libp2p host. Injected to allow mocking in tests.
-    private let hostBuilder: @Sendable () -> LibP2PHosting
+    private let hostBuilder: @Sendable () throws -> LibP2PHosting
     /// The underlying libp2p host instance once started.
     private var host: LibP2PHosting?
     /// Indicates whether the node is actively running.
@@ -167,11 +175,11 @@ actor P2PNode {
 
 
     init(bootstrapPeers: [String] = [],
-         hostBuilder: @escaping () -> LibP2PHosting = {
+         hostBuilder: @escaping () throws -> LibP2PHosting = {
 #if canImport(LibP2P)
-            LibP2PHost()
+            return try LibP2PHost()
 #else
-            NoopLibP2PHost()
+            return NoopLibP2PHost()
 #endif
          },
          keyDerivation: @escaping (Curve25519.KeyAgreement.PrivateKey, Data) throws -> SymmetricKey = Encryption.deriveSharedSecret) {
@@ -187,10 +195,10 @@ actor P2PNode {
 
     /// Starts the networking stack by creating a libp2p host, performing
     /// bootstrap against known peers and enabling NAT traversal.
-    func start() {
+    func start() throws {
         guard !isRunning else { return }
 
-        let host = hostBuilder()
+        let host = try hostBuilder()
         self.host = host
         host.setStreamHandler { stream in
             Task { await self.handleIncoming(stream: stream) }
@@ -220,8 +228,9 @@ actor P2PNode {
     }
 
     /// Opens a new libp2p stream to the given peer.
-    func openStream(to peer: Peer) -> LibP2PStream? {
-        guard let stream = host?.openStream(to: peer) else { return nil }
+    func openStream(to peer: Peer) throws -> LibP2PStream? {
+        guard let host = host else { return nil }
+        let stream = try host.openStream(to: peer)
         stream.setDataHandler { data in
             Task { await self.handleIncomingData(data, over: stream) }
         }
@@ -298,6 +307,11 @@ actor P2PNode {
         stream.setDataHandler { data in
             Task { await self.handleIncomingData(data, over: stream) }
         }
+    }
+
+    /// Convenience wrapper that forwards incoming data to the peer-based handler.
+    private func handleIncomingData(_ data: Data, over stream: LibP2PStream) async {
+        handleIncomingData(data, from: stream.peer)
     }
 
 

--- a/Tests/WeaveTests/P2PNodeTests.swift
+++ b/Tests/WeaveTests/P2PNodeTests.swift
@@ -13,16 +13,16 @@ final class P2PNodeTests: XCTestCase {
         func bootstrap(peers: [String]) { bootstrapped = peers }
         func enableNAT() { natEnabled = true }
         func stop() { stopCount += 1 }
-        func openStream(to peer: Peer) -> LibP2PStream { NoopLibP2PStream(peer: peer) }
+        func openStream(to peer: Peer) throws -> LibP2PStream { NoopLibP2PStream(peer: peer) }
         func setStreamHandler(_ handler: @escaping (LibP2PStream) -> Void) {}
     }
 
-    func testStartBootstrapsAndEnablesNAT() async {
+    func testStartBootstrapsAndEnablesNAT() async throws {
         let mock = MockHost()
         let node = P2PNode(bootstrapPeers: ["1.2.3.4:4001"], hostBuilder: { mock })
 
         XCTAssertFalse(await node.isRunning)
-        await node.start()
+        try await node.start()
 
         XCTAssertTrue(await node.isRunning)
         XCTAssertEqual(mock.startCount, 1)
@@ -30,10 +30,10 @@ final class P2PNodeTests: XCTestCase {
         XCTAssertTrue(mock.natEnabled)
     }
 
-    func testStopShutsDownHost() async {
+    func testStopShutsDownHost() async throws {
         let mock = MockHost()
         let node = P2PNode(hostBuilder: { mock })
-        await node.start()
+        try await node.start()
         await node.stop()
 
         XCTAssertFalse(await node.isRunning)
@@ -155,7 +155,7 @@ final class P2PNodeTests: XCTestCase {
         func enableNAT() {}
         func stop() {}
 
-        func openStream(to peer: Peer) -> LibP2PStream {
+        func openStream(to peer: Peer) throws -> LibP2PStream {
             let local = MockStream(peer: peer)
             if let (remoteHost, _) = peers[peer.id] {
                 let remote = MockStream(peer: self.selfPeer)
@@ -198,20 +198,24 @@ final class P2PNodeTests: XCTestCase {
             XCTAssertEqual(String(decoding: message.payload, as: UTF8.self), "ping")
 
             XCTAssertEqual(peer.id, peerA.id)
-            Task { try? await nodeB.sendMessage(Data("pong".utf8), over: stream) }
+            Task {
+                if let s = try? await nodeB.openStream(to: peer) {
+                    try? await nodeB.sendMessage(Data("pong".utf8), over: s)
+                }
+            }
             expB.fulfill()
         }
 
-        await nodeA.start()
-        await nodeB.start()
+        try await nodeA.start()
+        try await nodeB.start()
 
-        let streamAB = await nodeA.openStream(to: peerB)!
+        let streamAB = try await nodeA.openStream(to: peerB)!
 
         let ping = Message(type: "ping", payload: Data("ping".utf8), metadata: nil)
         try await nodeA.sendMessage(ping, over: streamAB)
         await fulfillment(of: [expB], timeout: 1.0)
 
-        let streamBA = await nodeB.openStream(to: peerA)!
+        let streamBA = try await nodeB.openStream(to: peerA)!
         let pong = Message(type: "pong", payload: Data("pong".utf8), metadata: nil)
         try await nodeB.sendMessage(pong, over: streamBA)
         await fulfillment(of: [expA], timeout: 1.0)


### PR DESCRIPTION
## Summary
- remove force-unwraps in LibP2P host initialization and stream creation
- propagate stream and host creation errors through `P2PNode` APIs
- adjust tests to use new throwing behaviors

## Testing
- `swift test` *(fails: unable to access https://github.com/libp2p/swift-libp2p.git, CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6890101451b8832bab2af5b45a215a9f