### PR TITLE
Add test for re-deriving shared keys after invalidation

### DIFF
--- a/Tests/WeaveTests/P2PNodeTests.swift
+++ b/Tests/WeaveTests/P2PNodeTests.swift
@@ -89,6 +89,31 @@ final class P2PNodeTests: XCTestCase {
 
     }
 
+    func testInvalidateSharedKeyForcesDerivation() throws {
+        var derivationCalls = 0
+        let node = P2PNode(keyDerivation: { privateKey, peerPublicKey in
+            derivationCalls += 1
+            return try Encryption.deriveSharedSecret(privateKey: privateKey, peerPublicKey: peerPublicKey)
+        })
+
+        let keys = Encryption.generateKeyPair()
+        let peer = try Peer(publicKey: keys.publicKey, latitude: 0, longitude: 0)
+        let message = Data("hi".utf8)
+
+        _ = try node.send(message, to: peer)
+        XCTAssertEqual(derivationCalls, 1)
+
+        // Cached key should prevent additional derivations
+        _ = try node.send(message, to: peer)
+        XCTAssertEqual(derivationCalls, 1)
+
+        node.invalidateSharedKey(for: peer.id)
+
+        // After invalidation, derivation should occur again
+        _ = try node.send(message, to: peer)
+        XCTAssertEqual(derivationCalls, 2)
+    }
+
     func testCacheEvictsLeastRecentlyUsedPeer() throws {
         var derivationCalls = 0
         let node = P2PNode(keyDerivation: { privateKey, peerPublicKey in


### PR DESCRIPTION
## Summary
- cover that invalidating a peer's shared key forces re-derivation on next send

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689010155e10832ba3cda629f1232195