### PR TITLE
Handle authorization errors in LocationService

### DIFF
--- a/Sources/LocationService.swift
+++ b/Sources/LocationService.swift
@@ -8,6 +8,12 @@ protocol LocationServiceDelegate: AnyObject {
     func locationService(_ service: LocationService, didFailWithError error: Error)
 }
 
+/// Errors that can be emitted by ``LocationService``.
+enum LocationServiceError: Error {
+    case authorizationDenied
+    case authorizationRestricted
+}
+
 /// A simple wrapper around `CLLocationManager` that requests
 /// permission and forwards coordinate updates to its delegate or
 /// callback.
@@ -36,6 +42,14 @@ final class LocationService: NSObject, CLLocationManagerDelegate {
             manager.requestWhenInUseAuthorization()
         case .authorizedWhenInUse, .authorizedAlways:
             manager.startUpdatingLocation()
+        case .denied:
+            let error = LocationServiceError.authorizationDenied
+            delegate?.locationService(self, didFailWithError: error)
+            onError?(error)
+        case .restricted:
+            let error = LocationServiceError.authorizationRestricted
+            delegate?.locationService(self, didFailWithError: error)
+            onError?(error)
         default:
             break
         }
@@ -55,8 +69,19 @@ final class LocationService: NSObject, CLLocationManagerDelegate {
     // MARK: - CLLocationManagerDelegate
 
     func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
-        if status == .authorizedWhenInUse || status == .authorizedAlways {
+        switch status {
+        case .authorizedWhenInUse, .authorizedAlways:
             manager.startUpdatingLocation()
+        case .denied:
+            let error = LocationServiceError.authorizationDenied
+            delegate?.locationService(self, didFailWithError: error)
+            onError?(error)
+        case .restricted:
+            let error = LocationServiceError.authorizationRestricted
+            delegate?.locationService(self, didFailWithError: error)
+            onError?(error)
+        default:
+            break
         }
     }
 

--- a/Tests/WeaveTests/LocationServiceTests.swift
+++ b/Tests/WeaveTests/LocationServiceTests.swift
@@ -59,6 +59,36 @@ final class LocationServiceTests: XCTestCase {
         service.stop()
     }
 
+    func testAuthorizationDeniedAndRestrictedPropagateError() {
+        let delegateExpectation = expectation(description: "delegate error")
+        delegateExpectation.expectedFulfillmentCount = 2
+        let closureExpectation = expectation(description: "closure error")
+        closureExpectation.expectedFulfillmentCount = 2
+        let service = LocationService()
+
+        class Delegate: LocationServiceDelegate {
+            var expectation: XCTestExpectation?
+
+            func locationService(_ service: LocationService, didUpdateLatitude latitude: Double, longitude: Double) {}
+
+            func locationService(_ service: LocationService, didFailWithError error: Error) {
+                expectation?.fulfill()
+            }
+        }
+
+        let delegate = Delegate()
+        delegate.expectation = delegateExpectation
+        service.delegate = delegate
+
+        service.onError = { _ in closureExpectation.fulfill() }
+
+        service.locationManager(CLLocationManager(), didChangeAuthorization: .denied)
+        service.locationManager(CLLocationManager(), didChangeAuthorization: .restricted)
+
+        wait(for: [delegateExpectation, closureExpectation], timeout: 1.0)
+        service.stop()
+    }
+
     func testStopClearsDelegateAndClosures() {
         let service = LocationService()
 


### PR DESCRIPTION
## Summary
- propagate authorization errors via delegate and closure in `LocationService`
- add test coverage for denied and restricted authorization cases

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68901016825c832bb0f1840767e7ea9a