### PR TITLE
Surface decoding errors to consumers

### DIFF
--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -164,6 +164,8 @@ actor P2PNode {
 
     /// Handler invoked for decrypted inbound messages.
     private var messageHandler: (@Sendable (Message, Peer) -> Void)?
+    /// Handler invoked when decryption or decoding fails.
+    private var errorHandler: (@Sendable (Error, Peer) -> Void)?
 
 
     init(bootstrapPeers: [String] = [],
@@ -217,6 +219,11 @@ actor P2PNode {
     func setMessageHandler(_ handler: @escaping @Sendable (Message, Peer) -> Void) {
 
         messageHandler = handler
+    }
+
+    /// Register a callback to receive errors for failed inbound messages.
+    func setErrorHandler(_ handler: @escaping @Sendable (Error, Peer) -> Void) {
+        errorHandler = handler
     }
 
     /// Opens a new libp2p stream to the given peer.
@@ -300,14 +307,24 @@ actor P2PNode {
         }
     }
 
+    /// Convenience wrapper that extracts the peer from the stream.
+    private func handleIncomingData(_ data: Data, over stream: LibP2PStream) {
+        handleIncomingData(data, from: stream.peer)
+    }
 
     /// Decrypts data from a peer, decodes it to a `Message` and forwards it to the registered handler.
     private func handleIncomingData(_ data: Data, from peer: Peer) {
         guard let handler = messageHandler else { return }
-        if let decrypted = try? receive(data, from: peer),
-           let message = try? JSONDecoder().decode(Message.self, from: decrypted) {
+        do {
+            let decrypted = try receive(data, from: peer)
+            let message = try JSONDecoder().decode(Message.self, from: decrypted)
             handler(message, peer)
-
+        } catch {
+            if let errorHandler {
+                errorHandler(error, peer)
+            } else {
+                print("Failed to handle incoming data from \(peer.id): \(error)")
+            }
         }
     }
 }

--- a/Tests/WeaveTests/P2PNodeTests.swift
+++ b/Tests/WeaveTests/P2PNodeTests.swift
@@ -217,4 +217,34 @@ final class P2PNodeTests: XCTestCase {
         await fulfillment(of: [expA], timeout: 1.0)
 
     }
+
+    func testErrorHandlerInvokedOnDecryptionFailure() async throws {
+        let keysA = Encryption.generateKeyPair()
+        let peerA = try Peer(publicKey: keysA.publicKey, latitude: 0, longitude: 0)
+        let keysB = Encryption.generateKeyPair()
+        let peerB = try Peer(publicKey: keysB.publicKey, latitude: 0, longitude: 0)
+
+        let hostA = StreamHost(selfPeer: peerA)
+        let hostB = StreamHost(selfPeer: peerB)
+        hostA.connect(to: hostB, as: peerB)
+        hostB.connect(to: hostA, as: peerA)
+
+        let nodeA = P2PNode(hostBuilder: { hostA })
+        let nodeB = P2PNode(hostBuilder: { hostB })
+
+        let expError = expectation(description: "NodeB error handler invoked")
+        await nodeB.setMessageHandler { _, _ in
+            XCTFail("Message handler should not be called")
+        }
+        await nodeB.setErrorHandler { _, _ in expError.fulfill() }
+
+        await nodeA.start()
+        await nodeB.start()
+
+        let streamAB = await nodeA.openStream(to: peerB)!
+        // Send unencrypted data which will fail decryption on nodeB
+        streamAB.write(Data("garbage".utf8))
+
+        await fulfillment(of: [expError], timeout: 1.0)
+    }
 }


### PR DESCRIPTION
## Summary
- expose `setErrorHandler` on `P2PNode` so clients can observe failures
- catch and log decryption/decoding errors when handling incoming data
- test error handler when decryption fails

## Testing
- `swift test` *(fails: unable to clone https://github.com/libp2p/swift-libp2p.git, CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68901016f610832b9effec1b839a4b44