### PR TITLE
feat: add libp2p DHT and integrate with peer manager

### DIFF
--- a/Sources/DHT.swift
+++ b/Sources/DHT.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(LibP2P)
+import LibP2P
+#endif
 
 /// Protocol describing a minimal distributed hash table used for peer discovery.
 /// Implementations store peer IDs keyed by full geohashes and support lookups
@@ -46,4 +49,72 @@ public actor InMemoryDHT: DHT {
         }
     }
 }
+
+#if canImport(LibP2P)
+/// Distributed hash table backed by libp2p's Kademlia implementation.
+/// Peer identifiers are stored under their full geohash as well as all
+/// geohash prefixes to allow efficient prefix lookups.
+public actor LibP2PDHT: DHT {
+    /// Underlying Kademlia DHT instance.
+    private let kademlia: KademliaDHT
+
+    /// Creates a new libp2p backed DHT. A host may be provided when
+    /// integrating with an existing libp2p node. If omitted a fresh host is
+    /// constructed using libp2p's default `HostBuilder`.
+    public init(host: Host? = nil) {
+        if let host {
+            self.kademlia = host.kademlia
+        } else {
+            let built = try! HostBuilder().build()
+            self.kademlia = built.kademlia
+        }
+    }
+
+    public func store(peerID: UUID, geohash: String) async {
+        for length in 1...geohash.count {
+            let key = String(geohash.prefix(length))
+            var set = await loadSet(for: key)
+            set.insert(peerID)
+            if let data = try? JSONEncoder().encode(Array(set)) {
+                _ = try? await kademlia.put(key: key, value: data)
+            }
+        }
+    }
+
+    public func remove(peerID: UUID, geohash: String) async {
+        for length in 1...geohash.count {
+            let key = String(geohash.prefix(length))
+            var set = await loadSet(for: key)
+            set.remove(peerID)
+            if let data = try? JSONEncoder().encode(Array(set)) {
+                _ = try? await kademlia.put(key: key, value: data)
+            }
+        }
+    }
+
+    public func lookup(prefix: String) async -> [UUID] {
+        let set = await loadSet(for: prefix)
+        return Array(set)
+    }
+
+    /// Retrieves the set of peer identifiers stored for the given key.
+    private func loadSet(for key: String) async -> Set<UUID> {
+        guard let data = try? await kademlia.get(key: key),
+              let decoded = try? JSONDecoder().decode([UUID].self, from: data) else {
+            return []
+        }
+        return Set(decoded)
+    }
+}
+#else
+/// Fallback no-op implementation used when libp2p is unavailable. This allows
+/// the package to build on platforms where the libp2p dependency cannot be
+/// resolved (such as the testing environment).
+public actor LibP2PDHT: DHT {
+    public init() {}
+    public func store(peerID: UUID, geohash: String) async {}
+    public func remove(peerID: UUID, geohash: String) async {}
+    public func lookup(prefix: String) async -> [UUID] { [] }
+}
+#endif
 

--- a/Sources/PeerManager.swift
+++ b/Sources/PeerManager.swift
@@ -10,8 +10,19 @@ actor PeerManager {
     private var liked: Set<UUID> = []
     private let dht: any DHT
 
-    init(dht: any DHT = InMemoryDHT()) {
-        self.dht = dht
+    /// Creates a new manager. When no explicit DHT is provided a libp2p-backed
+    /// implementation is used if available, falling back to an in-memory table
+    /// for testing and platforms without libp2p.
+    init(dht: (any DHT)? = nil) {
+        if let dht {
+            self.dht = dht
+        } else {
+#if canImport(LibP2P)
+            self.dht = LibP2PDHT()
+#else
+            self.dht = InMemoryDHT()
+#endif
+        }
     }
 
     /// Marks a peer as blocked, excluding it from discovery APIs.


### PR DESCRIPTION
## Summary
- add LibP2PDHT using libp2p Kademlia to store peers by geohash
- update PeerManager to default to LibP2PDHT when libp2p is available

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6890101ac740832b9220bee81d066df0