### PR TITLE
Add LibP2P networking node

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,8 @@ let package = Package(
         .executable(name: "weave", targets: ["weave"])
     ],
     dependencies: [
+        // Swift libp2p implementation providing the `Host` we wrap in
+        // `LibP2PNode`.
         .package(url: "https://github.com/libp2p/swift-libp2p.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "2.7.0")
     ],

--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -138,6 +138,95 @@ struct NoopLibP2PStream: LibP2PStream {
     func setDataHandler(_ handler: @escaping (Data) -> Void) {}
 }
 
+/// Minimal wrapper around a libp2p host that exposes basic networking
+/// behaviour. This type is responsible for bootstrapping the host into the
+/// network, opening streams to other peers and decoding inbound messages. It
+/// purposefully omits any of the encryption or peer caching logic found in the
+/// higher level `P2PNode` actor so it can be used in simpler scenarios or when
+/// writing integration tests against the real libp2p implementation.
+actor LibP2PNode {
+    /// Known peers used to discover the wider network.
+    private let bootstrapPeers: [String]
+    /// Factory closure producing a host instance. Injected to allow mocking.
+    private let hostBuilder: @Sendable () throws -> LibP2PHosting
+    /// Underlying host once started.
+    private var host: LibP2PHosting?
+    /// Callback invoked for each successfully decoded inbound message.
+    private var messageHandler: (@Sendable (Message, Peer) -> Void)?
+
+    init(bootstrapPeers: [String] = [],
+         hostBuilder: @escaping () throws -> LibP2PHosting = {
+#if canImport(LibP2P)
+            return try LibP2PHost()
+#else
+            return NoopLibP2PHost()
+#endif
+         }) {
+        self.bootstrapPeers = bootstrapPeers
+        self.hostBuilder = hostBuilder
+    }
+
+    /// Start the underlying host and bootstrap to the configured peers. A
+    /// stream handler is registered so incoming messages are automatically
+    /// decoded and forwarded to the registered message handler.
+    func start() throws {
+        guard host == nil else { return }
+
+        let host = try hostBuilder()
+        self.host = host
+
+        host.setStreamHandler { stream in
+            Task { await self.handleIncoming(stream: stream) }
+        }
+        host.start()
+        if !bootstrapPeers.isEmpty {
+            host.bootstrap(peers: bootstrapPeers)
+        }
+    }
+
+    /// Shut the host down and remove any handlers.
+    func stop() {
+        host?.stop()
+        host = nil
+    }
+
+    /// Register a callback to receive decoded messages from remote peers.
+    func setMessageHandler(_ handler: @escaping @Sendable (Message, Peer) -> Void) {
+        messageHandler = handler
+    }
+
+    /// Open a new stream to the given peer.
+    func openStream(to peer: Peer) throws -> LibP2PStream? {
+        guard let host = host else { return nil }
+        let stream = try host.openStream(to: peer)
+        stream.setDataHandler { data in
+            Task { await self.handleIncomingData(data, from: stream.peer) }
+        }
+        return stream
+    }
+
+    /// Encode and send a message over the provided stream.
+    func sendMessage(_ message: Message, over stream: LibP2PStream) throws {
+        let data = try JSONEncoder().encode(message)
+        stream.write(data)
+    }
+
+    /// Handles a newly opened incoming stream by registering a data handler.
+    private func handleIncoming(stream: LibP2PStream) {
+        stream.setDataHandler { data in
+            Task { await self.handleIncomingData(data, from: stream.peer) }
+        }
+    }
+
+    /// Decode incoming data and forward to the registered handler if available.
+    private func handleIncomingData(_ data: Data, from peer: Peer) {
+        guard let handler = messageHandler else { return }
+        if let message = try? JSONDecoder().decode(Message.self, from: data) {
+            handler(message, peer)
+        }
+    }
+}
+
 /// A networking node backed by a libp2p host.
 /// The node is initialised with a list of bootstrap peers and is responsible
 /// for starting and stopping the underlying host.

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -3,10 +3,11 @@ import Foundation
 @main
 struct Main {
     static func main() async {
-        // Demonstration of using the PeerManager alongside a placeholder
-        // networking node that will eventually speak libp2p.
-        let node = P2PNode(bootstrapPeers: ["bootstrap.weave.example:4001"])
-        await node.start()
+        // Demonstration of using the PeerManager alongside a libp2p-backed
+        // networking node. The node bootstraps to a well known peer so it can
+        // discover the rest of the network as soon as the app launches.
+        let node = LibP2PNode(bootstrapPeers: ["bootstrap.weave.example:4001"])
+        try? await node.start()
 
         let manager = PeerManager()
 

--- a/Tests/WeaveTests/LibP2PNodeWrapperTests.swift
+++ b/Tests/WeaveTests/LibP2PNodeWrapperTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import weave
+
+final class LibP2PNodeWrapperTests: XCTestCase {
+    /// Simple mock host used to verify that bootstrapping occurs when the node starts.
+    final class MockHost: LibP2PHosting {
+        var started = false
+        var bootstrapped: [String] = []
+        var handler: ((LibP2PStream) -> Void)?
+
+        func start() { started = true }
+        func bootstrap(peers: [String]) { bootstrapped = peers }
+        func enableNAT() {}
+        func stop() {}
+        func openStream(to peer: Peer) throws -> LibP2PStream { NoopLibP2PStream(peer: peer) }
+        func setStreamHandler(_ handler: @escaping (LibP2PStream) -> Void) { self.handler = handler }
+    }
+
+    func testStartBootstrapsPeers() async throws {
+        let mock = MockHost()
+        let node = LibP2PNode(bootstrapPeers: ["1.2.3.4:4001"], hostBuilder: { mock })
+
+        try await node.start()
+
+        XCTAssertTrue(mock.started)
+        XCTAssertEqual(mock.bootstrapped, ["1.2.3.4:4001"])
+    }
+
+    // MARK: Message handling
+    final class MockStream: LibP2PStream {
+        let peer: Peer
+        var dataHandler: ((Data) -> Void)?
+        weak var remote: MockStream?
+
+        init(peer: Peer) { self.peer = peer }
+
+        func write(_ data: Data) { remote?.dataHandler?(data) }
+        func setDataHandler(_ handler: @escaping (Data) -> Void) { dataHandler = handler }
+    }
+
+    final class StreamHost: LibP2PHosting {
+        let selfPeer: Peer
+        var peers: [UUID: (host: StreamHost, peer: Peer)] = [:]
+        var handler: ((LibP2PStream) -> Void)?
+
+        init(selfPeer: Peer) { self.selfPeer = selfPeer }
+
+        func connect(to host: StreamHost, as peer: Peer) { peers[peer.id] = (host, peer) }
+
+        func start() {}
+        func bootstrap(peers: [String]) {}
+        func enableNAT() {}
+        func stop() {}
+
+        func openStream(to peer: Peer) throws -> LibP2PStream {
+            let local = MockStream(peer: peer)
+            if let (remoteHost, _) = peers[peer.id] {
+                let remote = MockStream(peer: self.selfPeer)
+                local.remote = remote
+                remote.remote = local
+                remoteHost.handler?(remote)
+            }
+            return local
+        }
+
+        func setStreamHandler(_ handler: @escaping (LibP2PStream) -> Void) { self.handler = handler }
+    }
+
+    func testMessageRoundTrip() async throws {
+        let peerA = try Peer(latitude: 0, longitude: 0)
+        let peerB = try Peer(latitude: 0, longitude: 0)
+
+        let hostA = StreamHost(selfPeer: peerA)
+        let hostB = StreamHost(selfPeer: peerB)
+        hostA.connect(to: hostB, as: peerB)
+        hostB.connect(to: hostA, as: peerA)
+
+        let nodeA = LibP2PNode(hostBuilder: { hostA })
+        let nodeB = LibP2PNode(hostBuilder: { hostB })
+        try await nodeA.start()
+        try await nodeB.start()
+
+        let expectation = expectation(description: "message delivered")
+        await nodeB.setMessageHandler { message, peer in
+            XCTAssertEqual(message.type, "text")
+            XCTAssertEqual(String(data: message.payload, encoding: .utf8), "hi")
+            XCTAssertEqual(peer.id, peerA.id)
+            expectation.fulfill()
+        }
+
+        let stream = try await nodeA.openStream(to: peerB)
+        let msg = Message(type: "text", payload: Data("hi".utf8), metadata: nil)
+        try await nodeA.sendMessage(msg, over: stream!)
+        await waitForExpectations(timeout: 1.0)
+    }
+}


### PR DESCRIPTION
## Summary
- Wrap libp2p host in new `LibP2PNode` actor that handles bootstrapping, stream handling and message forwarding.
- Start `LibP2PNode` on application launch and wire it for future network integration.
- Add tests for peer discovery and round-trip messaging via the libp2p wrapper.

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689015e1c498832bb640d4c2818c07a2