### PR TITLE
Add CoreLocation service with Combine publisher and tests

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSLocationWhenInUseUsageDescription</key>
+    <string>Your location is used to discover nearby peers.</string>
+</dict>
+</plist>

--- a/Sources/LocationService.swift
+++ b/Sources/LocationService.swift
@@ -1,14 +1,17 @@
 #if canImport(CoreLocation)
 import Foundation
 import CoreLocation
+#if canImport(Combine)
+import Combine
+#endif
 
 /// Delegate protocol to receive location updates and errors.
 protocol LocationServiceDelegate: AnyObject {
-    func locationService(_ service: LocationService, didUpdateLatitude latitude: Double, longitude: Double)
-    func locationService(_ service: LocationService, didFailWithError error: Error)
+    func locationService(_ service: CoreLocationService, didUpdateLatitude latitude: Double, longitude: Double)
+    func locationService(_ service: CoreLocationService, didFailWithError error: Error)
 }
 
-/// Errors that can be emitted by ``LocationService``.
+/// Errors that can be emitted by ``CoreLocationService``.
 enum LocationServiceError: Error {
     case authorizationDenied
     case authorizationRestricted
@@ -16,8 +19,9 @@ enum LocationServiceError: Error {
 
 /// A simple wrapper around `CLLocationManager` that requests
 /// permission and forwards coordinate updates to its delegate or
-/// callback.
-final class LocationService: NSObject, CLLocationManagerDelegate {
+/// callback.  Location events can also be observed using Combine
+/// publishers when available.
+final class CoreLocationService: NSObject, CLLocationManagerDelegate {
     private let manager = CLLocationManager()
     private var didStop = false
 
@@ -29,6 +33,20 @@ final class LocationService: NSObject, CLLocationManagerDelegate {
 
     /// Optional closure called when errors occur.
     var onError: ((Error) -> Void)?
+
+    #if canImport(Combine)
+    private let locationSubject = PassthroughSubject<(Double, Double), Never>()
+    /// Publishes new latitude/longitude pairs as they are received.
+    var locationPublisher: AnyPublisher<(Double, Double), Never> {
+        locationSubject.eraseToAnyPublisher()
+    }
+
+    private let errorSubject = PassthroughSubject<Error, Never>()
+    /// Publishes errors produced by the service.
+    var errorPublisher: AnyPublisher<Error, Never> {
+        errorSubject.eraseToAnyPublisher()
+    }
+    #endif
 
     override init() {
         super.init()
@@ -46,10 +64,16 @@ final class LocationService: NSObject, CLLocationManagerDelegate {
             let error = LocationServiceError.authorizationDenied
             delegate?.locationService(self, didFailWithError: error)
             onError?(error)
+            #if canImport(Combine)
+            errorSubject.send(error)
+            #endif
         case .restricted:
             let error = LocationServiceError.authorizationRestricted
             delegate?.locationService(self, didFailWithError: error)
             onError?(error)
+            #if canImport(Combine)
+            errorSubject.send(error)
+            #endif
         default:
             break
         }
@@ -64,6 +88,10 @@ final class LocationService: NSObject, CLLocationManagerDelegate {
         delegate = nil
         onLocationUpdate = nil
         onError = nil
+        #if canImport(Combine)
+        locationSubject.send(completion: .finished)
+        errorSubject.send(completion: .finished)
+        #endif
     }
 
     // MARK: - CLLocationManagerDelegate
@@ -76,10 +104,16 @@ final class LocationService: NSObject, CLLocationManagerDelegate {
             let error = LocationServiceError.authorizationDenied
             delegate?.locationService(self, didFailWithError: error)
             onError?(error)
+            #if canImport(Combine)
+            errorSubject.send(error)
+            #endif
         case .restricted:
             let error = LocationServiceError.authorizationRestricted
             delegate?.locationService(self, didFailWithError: error)
             onError?(error)
+            #if canImport(Combine)
+            errorSubject.send(error)
+            #endif
         default:
             break
         }
@@ -91,11 +125,17 @@ final class LocationService: NSObject, CLLocationManagerDelegate {
         let lon = location.coordinate.longitude
         delegate?.locationService(self, didUpdateLatitude: lat, longitude: lon)
         onLocationUpdate?(lat, lon)
+        #if canImport(Combine)
+        locationSubject.send((lat, lon))
+        #endif
     }
 
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
         delegate?.locationService(self, didFailWithError: error)
         onError?(error)
+        #if canImport(Combine)
+        errorSubject.send(error)
+        #endif
     }
 
     deinit {

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -19,7 +19,7 @@ struct Main {
 
 #if canImport(CoreLocation)
         // Track the device's location and feed updates into the peer manager
-        let locationService = LocationService()
+        let locationService = CoreLocationService()
         locationService.onLocationUpdate = { lat, lon in
             Task {
                 await manager.updateLocation(id: me.id, latitude: lat, longitude: lon)

--- a/Tests/WeaveTests/CoreLocationServicePublisherTests.swift
+++ b/Tests/WeaveTests/CoreLocationServicePublisherTests.swift
@@ -1,0 +1,29 @@
+#if canImport(CoreLocation) && canImport(Combine)
+import XCTest
+import CoreLocation
+import Combine
+@testable import weave
+
+final class CoreLocationServicePublisherTests: XCTestCase {
+    private var cancellables = Set<AnyCancellable>()
+
+    func testLocationPublisherEmitsCoordinates() {
+        let service = CoreLocationService()
+        let expectation = expectation(description: "publisher emits")
+
+        service.locationPublisher
+            .sink { lat, lon in
+                XCTAssertEqual(lat, 42.0)
+                XCTAssertEqual(lon, -71.0)
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        let simulated = CLLocation(latitude: 42.0, longitude: -71.0)
+        service.locationManager(CLLocationManager(), didUpdateLocations: [simulated])
+
+        waitForExpectations(timeout: 1.0)
+        service.stop()
+    }
+}
+#endif

--- a/Tests/WeaveTests/CoreLocationServiceTests.swift
+++ b/Tests/WeaveTests/CoreLocationServiceTests.swift
@@ -3,10 +3,10 @@ import XCTest
 import CoreLocation
 @testable import weave
 
-final class LocationServiceTests: XCTestCase {
+final class CoreLocationServiceTests: XCTestCase {
     func testLocationUpdatesFeedPeerManager() async throws {
         let expectation = expectation(description: "location update")
-        let service = LocationService()
+        let service = CoreLocationService()
         let manager = PeerManager()
         let peer = try Peer(latitude: 0.0, longitude: 0.0)
         await manager.add(peer)
@@ -34,14 +34,14 @@ final class LocationServiceTests: XCTestCase {
     func testErrorPropagation() {
         let delegateExpectation = expectation(description: "delegate error")
         let closureExpectation = expectation(description: "closure error")
-        let service = LocationService()
+        let service = CoreLocationService()
 
         class Delegate: LocationServiceDelegate {
             var expectation: XCTestExpectation?
 
-            func locationService(_ service: LocationService, didUpdateLatitude latitude: Double, longitude: Double) {}
+            func locationService(_ service: CoreLocationService, didUpdateLatitude latitude: Double, longitude: Double) {}
 
-            func locationService(_ service: LocationService, didFailWithError error: Error) {
+            func locationService(_ service: CoreLocationService, didFailWithError error: Error) {
                 expectation?.fulfill()
             }
         }
@@ -64,14 +64,14 @@ final class LocationServiceTests: XCTestCase {
         delegateExpectation.expectedFulfillmentCount = 2
         let closureExpectation = expectation(description: "closure error")
         closureExpectation.expectedFulfillmentCount = 2
-        let service = LocationService()
+        let service = CoreLocationService()
 
         class Delegate: LocationServiceDelegate {
             var expectation: XCTestExpectation?
 
-            func locationService(_ service: LocationService, didUpdateLatitude latitude: Double, longitude: Double) {}
+            func locationService(_ service: CoreLocationService, didUpdateLatitude latitude: Double, longitude: Double) {}
 
-            func locationService(_ service: LocationService, didFailWithError error: Error) {
+            func locationService(_ service: CoreLocationService, didFailWithError error: Error) {
                 expectation?.fulfill()
             }
         }
@@ -90,11 +90,11 @@ final class LocationServiceTests: XCTestCase {
     }
 
     func testStopClearsDelegateAndClosures() {
-        let service = LocationService()
+        let service = CoreLocationService()
 
         class Delegate: LocationServiceDelegate {
-            func locationService(_ service: LocationService, didUpdateLatitude latitude: Double, longitude: Double) {}
-            func locationService(_ service: LocationService, didFailWithError error: Error) {}
+            func locationService(_ service: CoreLocationService, didUpdateLatitude latitude: Double, longitude: Double) {}
+            func locationService(_ service: CoreLocationService, didFailWithError error: Error) {}
         }
 
         let delegate = Delegate()
@@ -110,7 +110,7 @@ final class LocationServiceTests: XCTestCase {
     }
 
     func testDeinitClearsManagerDelegate() {
-        var service: LocationService? = LocationService()
+        var service: CoreLocationService? = CoreLocationService()
 
         let mirror = Mirror(reflecting: service as Any)
         guard let manager = mirror.children.first(where: { $0.label == "manager" })?.value as? CLLocationManager else {

--- a/Tests/WeaveTests/LocationIntegrationTests.swift
+++ b/Tests/WeaveTests/LocationIntegrationTests.swift
@@ -10,7 +10,7 @@ final class LocationIntegrationTests: XCTestCase {
         let peer = try Peer(latitude: 0.0, longitude: 0.0)
         await manager.add(peer)
 
-        let service = LocationService()
+        let service = CoreLocationService()
         service.onLocationUpdate = { lat, lon in
             Task {
                 await manager.updateLocation(id: peer.id, latitude: lat, longitude: lon)


### PR DESCRIPTION
## Summary
- Introduce `CoreLocationService` wrapping `CLLocationManager`, providing closure callbacks and Combine publishers for coordinates and errors
- Include `NSLocationWhenInUseUsageDescription` in Info.plist for iOS builds
- Add Combine-based unit test to verify that location updates are published

## Testing
- `swift test` *(failed: Failed to clone repository https://github.com/libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689015e2c924832b942dca5a9c6c26ff