### PR TITLE
Implement CryptoKit message encryption

### DIFF
--- a/Sources/Encryption.swift
+++ b/Sources/Encryption.swift
@@ -43,6 +43,24 @@ enum Encryption {
         return try AES.GCM.open(box, using: key)
     }
 
+    /// Encrypts message data for a peer by deriving a shared secret
+    /// using the caller's private key and the peer's public key.
+    static func encryptMessage(_ message: Data,
+                               from privateKey: Curve25519.KeyAgreement.PrivateKey,
+                               to peerPublicKey: Data) throws -> Data {
+        let key = try deriveSharedSecret(privateKey: privateKey, peerPublicKey: peerPublicKey)
+        return try encrypt(message, using: key)
+    }
+
+    /// Decrypts message data sent by a peer using the receiver's private key
+    /// and the sender's public key to derive the shared secret.
+    static func decryptMessage(_ message: Data,
+                               with privateKey: Curve25519.KeyAgreement.PrivateKey,
+                               senderPublicKey: Data) throws -> Data {
+        let key = try deriveSharedSecret(privateKey: privateKey, peerPublicKey: senderPublicKey)
+        return try decrypt(message, using: key)
+    }
+
     enum EncryptionError: Error {
         case invalidSealedBox
     }

--- a/Sources/Message.swift
+++ b/Sources/Message.swift
@@ -1,7 +1,25 @@
 import Foundation
+import Crypto
 
 struct Message: Codable, Equatable {
     let type: String
     let payload: Data
     let metadata: [String: String]?
+}
+
+extension Message {
+    /// Encodes and encrypts the message using the given key pair and peer public key.
+    func encrypted(from privateKey: Curve25519.KeyAgreement.PrivateKey,
+                   to peerPublicKey: Data) throws -> Data {
+        let data = try JSONEncoder().encode(self)
+        return try Encryption.encryptMessage(data, from: privateKey, to: peerPublicKey)
+    }
+
+    /// Decrypts and decodes an encrypted message.
+    static func decrypted(_ data: Data,
+                          with privateKey: Curve25519.KeyAgreement.PrivateKey,
+                          senderPublicKey: Data) throws -> Message {
+        let plaintext = try Encryption.decryptMessage(data, with: privateKey, senderPublicKey: senderPublicKey)
+        return try JSONDecoder().decode(Message.self, from: plaintext)
+    }
 }

--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -246,8 +246,10 @@ actor P2PNode {
 
     /// Encodes, encrypts and sends a message over an existing stream.
     func sendMessage(_ message: Message, over stream: LibP2PStream) throws {
-        let data = try JSONEncoder().encode(message)
-        let encrypted = try send(data, to: stream.peer)
+        guard let peerKey = stream.peer.publicKey else {
+            throw P2PError.missingPeerPublicKey
+        }
+        let encrypted = try message.encrypted(from: privateKey, to: peerKey)
         stream.write(encrypted)
     }
 
@@ -325,8 +327,10 @@ actor P2PNode {
     private func handleIncomingData(_ data: Data, from peer: Peer) {
         guard let handler = messageHandler else { return }
         do {
-            let decrypted = try receive(data, from: peer)
-            let message = try JSONDecoder().decode(Message.self, from: decrypted)
+            guard let senderKey = peer.publicKey else {
+                throw P2PError.missingPeerPublicKey
+            }
+            let message = try Message.decrypted(data, with: privateKey, senderPublicKey: senderKey)
             handler(message, peer)
         } catch {
             if let errorHandler {

--- a/Tests/WeaveTests/EncryptionTests.swift
+++ b/Tests/WeaveTests/EncryptionTests.swift
@@ -28,5 +28,14 @@ final class EncryptionTests: XCTestCase {
         let decrypted = try await bobNode.receive(encrypted, from: alicePeer)
         XCTAssertEqual(message, decrypted)
     }
+
+    func testMessageEncryptionRoundTrip() throws {
+        let alice = Encryption.generateKeyPair()
+        let bob = Encryption.generateKeyPair()
+        let original = Message(type: "greet", payload: Data("hi".utf8), metadata: nil)
+        let encrypted = try original.encrypted(from: alice.privateKey, to: bob.publicKey)
+        let decoded = try Message.decrypted(encrypted, with: bob.privateKey, senderPublicKey: alice.publicKey)
+        XCTAssertEqual(original, decoded)
+    }
 }
 


### PR DESCRIPTION
## Summary
- Add helper APIs for encrypting and decrypting messages using Curve25519 key agreement and AES.GCM
- Extend `Message` and `P2PNode` to use the new encryption helpers for stream communication
- Cover key generation and message encryption flows with unit tests

## Testing
- `swift test` *(fails: unable to fetch https://github.com/libp2p/swift-libp2p.git, CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_689015e36c84832bb6843cd5169516bc