### PR TITLE
Implement encrypted P2P messaging and tests

### DIFF
--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -335,10 +335,9 @@ actor P2PNode {
 
     /// Encodes, encrypts and sends a message over an existing stream.
     func sendMessage(_ message: Message, over stream: LibP2PStream) throws {
-        guard let peerKey = stream.peer.publicKey else {
-            throw P2PError.missingPeerPublicKey
-        }
-        let encrypted = try message.encrypted(from: privateKey, to: peerKey)
+        let key = try sharedKey(with: stream.peer)
+        let data = try JSONEncoder().encode(message)
+        let encrypted = try Encryption.encrypt(data, using: key)
         stream.write(encrypted)
     }
 
@@ -416,10 +415,9 @@ actor P2PNode {
     private func handleIncomingData(_ data: Data, from peer: Peer) {
         guard let handler = messageHandler else { return }
         do {
-            guard let senderKey = peer.publicKey else {
-                throw P2PError.missingPeerPublicKey
-            }
-            let message = try Message.decrypted(data, with: privateKey, senderPublicKey: senderKey)
+            let key = try sharedKey(with: peer)
+            let plaintext = try Encryption.decrypt(data, using: key)
+            let message = try JSONDecoder().decode(Message.self, from: plaintext)
             handler(message, peer)
         } catch {
             if let errorHandler {

--- a/Tests/WeaveTests/EncryptionTests.swift
+++ b/Tests/WeaveTests/EncryptionTests.swift
@@ -37,5 +37,84 @@ final class EncryptionTests: XCTestCase {
         let decoded = try Message.decrypted(encrypted, with: bob.privateKey, senderPublicKey: alice.publicKey)
         XCTAssertEqual(original, decoded)
     }
+
+    func testNodesExchangeEncryptedMessagesOverStream() async throws {
+        final class MockStream: LibP2PStream {
+            let peer: Peer
+            var dataHandler: ((Data) -> Void)?
+            weak var remote: MockStream?
+            var onWrite: ((Data) -> Void)?
+            init(peer: Peer) { self.peer = peer }
+            func write(_ data: Data) {
+                onWrite?(data)
+                remote?.dataHandler?(data)
+            }
+            func setDataHandler(_ handler: @escaping (Data) -> Void) { dataHandler = handler }
+        }
+
+        final class StreamHost: LibP2PHosting {
+            let selfPeer: Peer
+            var peers: [UUID: (host: StreamHost, peer: Peer)] = [:]
+            var handler: ((LibP2PStream) -> Void)?
+
+            init(selfPeer: Peer) { self.selfPeer = selfPeer }
+
+            func connect(to host: StreamHost, as peer: Peer) { peers[peer.id] = (host, peer) }
+
+            func start() {}
+            func bootstrap(peers: [String]) {}
+            func enableNAT() {}
+            func stop() {}
+
+            func openStream(to peer: Peer) throws -> LibP2PStream {
+                let local = MockStream(peer: peer)
+                if let (remoteHost, _) = peers[peer.id] {
+                    let remote = MockStream(peer: self.selfPeer)
+                    local.remote = remote
+                    remote.remote = local
+                    remoteHost.handler?(remote)
+                }
+                return local
+            }
+
+            func setStreamHandler(_ handler: @escaping (LibP2PStream) -> Void) { self.handler = handler }
+        }
+
+        let keysA = Encryption.generateKeyPair()
+        let peerA = try Peer(publicKey: keysA.publicKey, latitude: 0, longitude: 0)
+        let keysB = Encryption.generateKeyPair()
+        let peerB = try Peer(publicKey: keysB.publicKey, latitude: 0, longitude: 0)
+
+        let hostA = StreamHost(selfPeer: peerA)
+        let hostB = StreamHost(selfPeer: peerB)
+        hostA.connect(to: hostB, as: peerB)
+        hostB.connect(to: hostA, as: peerA)
+
+        let nodeA = P2PNode(hostBuilder: { hostA })
+        let nodeB = P2PNode(hostBuilder: { hostB })
+
+        let exp = expectation(description: "NodeB received message")
+        await nodeB.setMessageHandler { message, peer in
+            XCTAssertEqual(message.type, "greet")
+            XCTAssertEqual(String(decoding: message.payload, as: UTF8.self), "hello")
+            XCTAssertEqual(peer.id, peerA.id)
+            exp.fulfill()
+        }
+
+        await nodeA.start()
+        await nodeB.start()
+
+        let stream = try await nodeA.openStream(to: peerB)! as! MockStream
+        var captured: Data?
+        stream.onWrite = { data in captured = data }
+
+        let msg = Message(type: "greet", payload: Data("hello".utf8), metadata: nil)
+        try await nodeA.sendMessage(msg, over: stream)
+
+        await fulfillment(of: [exp], timeout: 1.0)
+
+        XCTAssertNotNil(captured)
+        XCTAssertNil(try? JSONDecoder().decode(Message.self, from: captured!))
+    }
 }
 

--- a/Tests/WeaveTests/P2PNodeTests.swift
+++ b/Tests/WeaveTests/P2PNodeTests.swift
@@ -225,7 +225,8 @@ final class P2PNodeTests: XCTestCase {
             XCTAssertEqual(peer.id, peerA.id)
             Task {
                 if let s = try? await nodeB.openStream(to: peer) {
-                    try? await nodeB.sendMessage(Data("pong".utf8), over: s)
+                    let pong = Message(type: "pong", payload: Data("pong".utf8), metadata: nil)
+                    try? await nodeB.sendMessage(pong, over: s)
                 }
             }
             expB.fulfill()


### PR DESCRIPTION
## Summary
- derive shared symmetric keys and encrypt data in `P2PNode.sendMessage`
- decrypt inbound payloads via shared keys before decoding
- add integration test demonstrating encrypted message exchange between peers

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68901b425930832ba902c0b1fa40ad16