### PR TITLE
Implement geohash prefix bucketing for DHT lookups

### DIFF
--- a/Sources/DHT.swift
+++ b/Sources/DHT.swift
@@ -17,36 +17,40 @@ public protocol DHT {
     func lookup(prefix: String) async -> [UUID]
 }
 
-/// Simple in-memory DHT implementation used for testing. This actor maintains
-/// a dictionary mapping full geohashes to the set of peer identifiers within
-/// that cell.
+/// Simple in-memory DHT implementation used for testing. This actor
+/// maintains a dictionary mapping geohash prefixes to the set of peer
+/// identifiers stored under that prefix. Peers are indexed under their full
+/// geohash as well as all prefixes, mirroring the behavior of the libp2p
+/// backed implementation.
 public actor InMemoryDHT: DHT {
     private var index: [String: Set<UUID>] = [:]
 
     public init() {}
 
     public func store(peerID: UUID, geohash: String) async {
-        var bucket = index[geohash] ?? Set<UUID>()
-        bucket.insert(peerID)
-        index[geohash] = bucket
+        for length in 1...geohash.count {
+            let key = String(geohash.prefix(length))
+            var bucket = index[key] ?? Set<UUID>()
+            bucket.insert(peerID)
+            index[key] = bucket
+        }
     }
 
     public func remove(peerID: UUID, geohash: String) async {
-        guard var bucket = index[geohash] else { return }
-        bucket.remove(peerID)
-        if bucket.isEmpty {
-            index.removeValue(forKey: geohash)
-        } else {
-            index[geohash] = bucket
+        for length in 1...geohash.count {
+            let key = String(geohash.prefix(length))
+            guard var bucket = index[key] else { continue }
+            bucket.remove(peerID)
+            if bucket.isEmpty {
+                index.removeValue(forKey: key)
+            } else {
+                index[key] = bucket
+            }
         }
     }
 
     public func lookup(prefix: String) async -> [UUID] {
-        index.reduce(into: [UUID]()) { result, entry in
-            if entry.key.hasPrefix(prefix) {
-                result.append(contentsOf: entry.value)
-            }
-        }
+        Array(index[prefix] ?? [])
     }
 }
 

--- a/Tests/WeaveTests/DHTTests.swift
+++ b/Tests/WeaveTests/DHTTests.swift
@@ -11,6 +11,8 @@ final class DHTTests: XCTestCase {
         await dht.store(peerID: id1, geohash: "abcd123")
         await dht.store(peerID: id2, geohash: "abef456")
         await dht.store(peerID: id3, geohash: "xyz789")
+        let aResults = await dht.lookup(prefix: "a")
+        XCTAssertEqual(Set(aResults), Set([id1, id2]))
         let abResults = await dht.lookup(prefix: "ab")
         XCTAssertEqual(Set(abResults), Set([id1, id2]))
         let abcResults = await dht.lookup(prefix: "abc")
@@ -25,8 +27,10 @@ final class DHTTests: XCTestCase {
         await dht.store(peerID: id1, geohash: "foo")
         await dht.store(peerID: id2, geohash: "foo")
         await dht.remove(peerID: id1, geohash: "foo")
+        XCTAssertEqual(await dht.lookup(prefix: "f"), [id2])
         XCTAssertEqual(await dht.lookup(prefix: "foo"), [id2])
         await dht.remove(peerID: id2, geohash: "foo")
+        XCTAssertTrue(await dht.lookup(prefix: "f").isEmpty)
         XCTAssertTrue(await dht.lookup(prefix: "foo").isEmpty)
     }
 }


### PR DESCRIPTION
## Summary
- index peers under geohash prefixes for efficient lookups
- add unit tests covering prefix-based lookups and removals

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68901b42ea50832bbad71c8c32bd2134