### PR TITLE
Surface errors when constructing LibP2PDHT

### DIFF
--- a/Sources/DHT.swift
+++ b/Sources/DHT.swift
@@ -65,15 +65,19 @@ public actor LibP2PDHT: DHT {
     /// integrating with an existing libp2p node. If omitted a fresh host is
     /// constructed using libp2p's default `HostBuilder` and started
     /// automatically.
-    public init(host: Host? = nil) {
+    public init(host: Host? = nil) throws {
         if let host {
             self.host = host
             self.kademlia = host.kademlia
         } else {
-            let built = try! HostBuilder().build()
-            _ = try? built.start().wait()
-            self.host = built
-            self.kademlia = built.kademlia
+            do {
+                let built = try HostBuilder().build()
+                _ = try built.start().wait()
+                self.host = built
+                self.kademlia = built.kademlia
+            } catch {
+                throw error
+            }
         }
     }
 

--- a/Sources/PeerManager.swift
+++ b/Sources/PeerManager.swift
@@ -18,7 +18,11 @@ actor PeerManager {
             self.dht = dht
         } else {
 #if canImport(LibP2P)
-            self.dht = LibP2PDHT()
+            if let libp2p = try? LibP2PDHT() {
+                self.dht = libp2p
+            } else {
+                self.dht = InMemoryDHT()
+            }
 #else
             self.dht = InMemoryDHT()
 #endif

--- a/Tests/WeaveTests/LibP2PIntegrationTests.swift
+++ b/Tests/WeaveTests/LibP2PIntegrationTests.swift
@@ -3,8 +3,8 @@ import XCTest
 
 final class LibP2PIntegrationTests: XCTestCase {
     func testPeerDiscoveryAcrossDHT() async throws {
-        let dhtA = LibP2PDHT()
-        let dhtB = LibP2PDHT()
+        let dhtA = try LibP2PDHT()
+        let dhtB = try LibP2PDHT()
         // Connect the DHT instances so stored values propagate
         for addr in dhtA.listenAddresses { dhtB.bootstrap(to: addr) }
         for addr in dhtB.listenAddresses { dhtA.bootstrap(to: addr) }


### PR DESCRIPTION
## Summary
- make LibP2PDHT initializer throwing and handle HostBuilder errors
- fall back to in-memory DHT if LibP2P host setup fails
- update LibP2P integration test for throwing initializer

## Testing
- `swift test` *(fails: fatal: unable to access 'https://github.com/libp2p/swift-libp2p.git/': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68901e50e8d0832bab7566a01516ac4b