### PR TITLE
Propagate DHT write errors

### DIFF
--- a/Sources/DHT.swift
+++ b/Sources/DHT.swift
@@ -1,15 +1,23 @@
 import Foundation
 import LibP2P
 
+/// Errors that can occur when writing values to the DHT.
+public enum DHTError: Error {
+    /// Encoding the peer identifier set failed.
+    case encodingFailed(Error)
+    /// The underlying Kademlia `put` operation failed.
+    case putFailed(Error)
+}
+
 /// Protocol describing a minimal distributed hash table used for peer discovery.
 /// Implementations store peer IDs keyed by full geohashes and support lookups
 /// by geohash prefix.
 public protocol DHT {
     /// Stores the given peer identifier under the provided full geohash.
-    func store(peerID: UUID, geohash: String) async
+    func store(peerID: UUID, geohash: String) async throws
 
     /// Removes the peer identifier from the given geohash bucket.
-    func remove(peerID: UUID, geohash: String) async
+    func remove(peerID: UUID, geohash: String) async throws
 
     /// Returns all peer identifiers whose stored geohash begins with the prefix.
     func lookup(prefix: String) async -> [UUID]
@@ -25,7 +33,7 @@ public actor InMemoryDHT: DHT {
 
     public init() {}
 
-    public func store(peerID: UUID, geohash: String) async {
+    public func store(peerID: UUID, geohash: String) async throws {
         for length in 1...geohash.count {
             let key = String(geohash.prefix(length))
             var bucket = index[key] ?? Set<UUID>()
@@ -34,7 +42,7 @@ public actor InMemoryDHT: DHT {
         }
     }
 
-    public func remove(peerID: UUID, geohash: String) async {
+    public func remove(peerID: UUID, geohash: String) async throws {
         for length in 1...geohash.count {
             let key = String(geohash.prefix(length))
             guard var bucket = index[key] else { continue }
@@ -89,24 +97,44 @@ public actor LibP2PDHT: DHT {
         host.listenAddresses.map { $0.description }
     }
 
-    public func store(peerID: UUID, geohash: String) async {
+    public func store(peerID: UUID, geohash: String) async throws {
         for length in 1...geohash.count {
             let key = String(geohash.prefix(length))
             var set = await loadSet(for: key)
             set.insert(peerID)
-            if let data = try? JSONEncoder().encode(Array(set)) {
-                _ = try? await kademlia.put(key: key, value: data)
+            let data: Data
+            do {
+                data = try JSONEncoder().encode(Array(set))
+            } catch {
+                print("[DHT] Failed to encode peer set for key \(key): \(error)")
+                throw DHTError.encodingFailed(error)
+            }
+            do {
+                try await kademlia.put(key: key, value: data)
+            } catch {
+                print("[DHT] Failed to put peer set for key \(key): \(error)")
+                throw DHTError.putFailed(error)
             }
         }
     }
 
-    public func remove(peerID: UUID, geohash: String) async {
+    public func remove(peerID: UUID, geohash: String) async throws {
         for length in 1...geohash.count {
             let key = String(geohash.prefix(length))
             var set = await loadSet(for: key)
             set.remove(peerID)
-            if let data = try? JSONEncoder().encode(Array(set)) {
-                _ = try? await kademlia.put(key: key, value: data)
+            let data: Data
+            do {
+                data = try JSONEncoder().encode(Array(set))
+            } catch {
+                print("[DHT] Failed to encode peer set for key \(key): \(error)")
+                throw DHTError.encodingFailed(error)
+            }
+            do {
+                try await kademlia.put(key: key, value: data)
+            } catch {
+                print("[DHT] Failed to put peer set for key \(key): \(error)")
+                throw DHTError.putFailed(error)
             }
         }
     }

--- a/Sources/LocationService.swift
+++ b/Sources/LocationService.swift
@@ -153,7 +153,7 @@ final class CoreLocationService: NSObject, CLLocationManagerDelegate {
         onLocationUpdate?(lat, lon)
         if let peerManager, let peerID {
             Task {
-                await peerManager.updateLocation(id: peerID, latitude: lat, longitude: lon)
+                try? await peerManager.updateLocation(id: peerID, latitude: lat, longitude: lon)
             }
         }
         #if canImport(Combine)

--- a/Sources/PeerManager.swift
+++ b/Sources/PeerManager.swift
@@ -62,18 +62,18 @@ actor PeerManager {
 
 
     /// Adds or updates a peer in the manager.
-    func add(_ peer: Peer) async {
+    func add(_ peer: Peer) async throws {
         if let existing = peerIndex[peer.id] {
-            await dht.remove(peerID: peer.id, geohash: existing.geohash)
+            try await dht.remove(peerID: peer.id, geohash: existing.geohash)
         }
         peerIndex[peer.id] = peer
-        await dht.store(peerID: peer.id, geohash: peer.geohash)
+        try await dht.store(peerID: peer.id, geohash: peer.geohash)
     }
 
     /// Removes a peer by id.
-    func remove(id: UUID) async {
+    func remove(id: UUID) async throws {
         if let peer = peerIndex.removeValue(forKey: id) {
-            await dht.remove(peerID: id, geohash: peer.geohash)
+            try await dht.remove(peerID: id, geohash: peer.geohash)
         }
         blocked.remove(id)
         liked.remove(id)
@@ -85,7 +85,7 @@ actor PeerManager {
     }
 
     /// Updates a peer's geographic location if it exists in the manager.
-    func updateLocation(id: UUID, latitude: Double, longitude: Double) async {
+    func updateLocation(id: UUID, latitude: Double, longitude: Double) async throws {
         guard var peer = peerIndex[id] else { return }
         let oldKey = peer.geohash
         peer.latitude = latitude
@@ -94,8 +94,8 @@ actor PeerManager {
         peerIndex[id] = peer
         let newKey = peer.geohash
         if oldKey != newKey {
-            await dht.remove(peerID: id, geohash: oldKey)
-            await dht.store(peerID: id, geohash: newKey)
+            try await dht.remove(peerID: id, geohash: oldKey)
+            try await dht.store(peerID: id, geohash: newKey)
         }
     }
 
@@ -255,10 +255,10 @@ actor PeerManager {
     }
 
     /// Removes peers that were last seen before the provided cutoff date.
-    func pruneStale(before cutoff: Date) async {
+    func pruneStale(before cutoff: Date) async throws {
         let stale = peerIndex.filter { $0.value.lastSeen < cutoff }
         for (id, peer) in stale {
-            await dht.remove(peerID: id, geohash: peer.geohash)
+            try await dht.remove(peerID: id, geohash: peer.geohash)
             peerIndex.removeValue(forKey: id)
         }
         blocked = blocked.filter { peerIndex[$0] != nil }
@@ -295,7 +295,7 @@ actor PeerManager {
         blocked = Set(snapshot.blocked.filter { peerIndex[$0] != nil })
         liked = Set(snapshot.liked.filter { peerIndex[$0] != nil && !blocked.contains($0) })
         for peer in snapshot.peers {
-            await dht.store(peerID: peer.id, geohash: peer.geohash)
+            try await dht.store(peerID: peer.id, geohash: peer.geohash)
         }
     }
 

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -16,14 +16,14 @@ struct Main {
         let selfLon = -122.4194
 
         let me = try! Peer(name: "Me", latitude: selfLat, longitude: selfLon, attributes: ["hobby": "hiking"])
-        await manager.add(me)
+        try? await manager.add(me)
 
 #if canImport(CoreLocation)
         // Track the device's location and feed updates into the peer manager
         let locationService = CoreLocationService()
         locationService.onLocationUpdate = { lat, lon in
             Task {
-                await manager.updateLocation(id: me.id, latitude: lat, longitude: lon)
+                try? await manager.updateLocation(id: me.id, latitude: lat, longitude: lon)
             }
         }
         locationService.start()
@@ -32,12 +32,12 @@ struct Main {
 
         // Add a peer in San Francisco
         let movingPeer = try! Peer(name: "Alice", latitude: 37.7750, longitude: -122.4183, attributes: ["hobby": "hiking", "likes": me.id.uuidString])
-        await manager.add(movingPeer)
+        try? await manager.add(movingPeer)
 
         // Add another peer in Los Angeles with the same hobby
         let laPeer = try! Peer(name: "Bob", latitude: 34.0522, longitude: -118.2437, attributes: ["hobby": "hiking"])
 
-        await manager.add(laPeer)
+        try? await manager.add(laPeer)
 
         // Query peers sharing the same geohash prefix as the moving peer (coarse area
         // match) and demonstrate attribute filtering.
@@ -71,7 +71,7 @@ struct Main {
         print("Peers after blocking LA user: \(nearbyPeers.count)")
 
         // Update the peer's location to New York
-        await manager.updateLocation(id: movingPeer.id, latitude: 40.7128, longitude: -74.0060)
+        try? await manager.updateLocation(id: movingPeer.id, latitude: 40.7128, longitude: -74.0060)
         nearbyPeers = await manager.peers(near: selfLat, longitude: selfLon, radius: 5.0)
         print("Nearby peers after move: \(nearbyPeers.count)")
 
@@ -115,9 +115,9 @@ struct Main {
 
         // Demonstrate pruning stale peers
         let stalePeer = try! Peer(latitude: 35.0, longitude: -120.0, lastSeen: Date(timeIntervalSinceNow: -7200))
-        await manager.add(stalePeer)
+        try? await manager.add(stalePeer)
         print("Total peers before pruning: \(await manager.allPeers().count)")
-        await manager.pruneStale(before: Date(timeIntervalSinceNow: -3600))
+        try? await manager.pruneStale(before: Date(timeIntervalSinceNow: -3600))
         print("Peers after pruning stale entries: \(await manager.allPeers().count)")
 
         // Fetch the most recently seen peers

--- a/Tests/WeaveTests/CoreLocationServiceTests.swift
+++ b/Tests/WeaveTests/CoreLocationServiceTests.swift
@@ -7,7 +7,7 @@ final class CoreLocationServiceTests: XCTestCase {
     func testLocationUpdatesFeedPeerManager() async throws {
         let manager = PeerManager()
         let peer = try Peer(latitude: 0.0, longitude: 0.0)
-        await manager.add(peer)
+        try await manager.add(peer)
 
         // Service automatically updates the peer manager when coordinates change
         let service = CoreLocationService(peerManager: manager, peerID: peer.id)

--- a/Tests/WeaveTests/DHTTests.swift
+++ b/Tests/WeaveTests/DHTTests.swift
@@ -3,14 +3,14 @@ import Foundation
 @testable import weave
 
 final class DHTTests: XCTestCase {
-    func testLookupReturnsIDsForMatchingPrefixes() async {
+    func testLookupReturnsIDsForMatchingPrefixes() async throws {
         let dht = InMemoryDHT()
         let id1 = UUID()
         let id2 = UUID()
         let id3 = UUID()
-        await dht.store(peerID: id1, geohash: "abcd123")
-        await dht.store(peerID: id2, geohash: "abef456")
-        await dht.store(peerID: id3, geohash: "xyz789")
+        try await dht.store(peerID: id1, geohash: "abcd123")
+        try await dht.store(peerID: id2, geohash: "abef456")
+        try await dht.store(peerID: id3, geohash: "xyz789")
         let aResults = await dht.lookup(prefix: "a")
         XCTAssertEqual(Set(aResults), Set([id1, id2]))
         let abResults = await dht.lookup(prefix: "ab")
@@ -20,16 +20,16 @@ final class DHTTests: XCTestCase {
         XCTAssertTrue(await dht.lookup(prefix: "nope").isEmpty)
     }
 
-    func testRemoveDeletesIDsAndEmptiesBuckets() async {
+    func testRemoveDeletesIDsAndEmptiesBuckets() async throws {
         let dht = InMemoryDHT()
         let id1 = UUID()
         let id2 = UUID()
-        await dht.store(peerID: id1, geohash: "foo")
-        await dht.store(peerID: id2, geohash: "foo")
-        await dht.remove(peerID: id1, geohash: "foo")
+        try await dht.store(peerID: id1, geohash: "foo")
+        try await dht.store(peerID: id2, geohash: "foo")
+        try await dht.remove(peerID: id1, geohash: "foo")
         XCTAssertEqual(await dht.lookup(prefix: "f"), [id2])
         XCTAssertEqual(await dht.lookup(prefix: "foo"), [id2])
-        await dht.remove(peerID: id2, geohash: "foo")
+        try await dht.remove(peerID: id2, geohash: "foo")
         XCTAssertTrue(await dht.lookup(prefix: "f").isEmpty)
         XCTAssertTrue(await dht.lookup(prefix: "foo").isEmpty)
     }

--- a/Tests/WeaveTests/LibP2PIntegrationTests.swift
+++ b/Tests/WeaveTests/LibP2PIntegrationTests.swift
@@ -10,7 +10,7 @@ final class LibP2PIntegrationTests: XCTestCase {
         for addr in dhtB.listenAddresses { dhtA.bootstrap(to: addr) }
 
         let peerID = UUID()
-        await dhtA.store(peerID: peerID, geohash: "u4pruydqqvj")
+        try await dhtA.store(peerID: peerID, geohash: "u4pruydqqvj")
         // Small delay to allow propagation
         try await Task.sleep(nanoseconds: 200_000_000)
         let results = await dhtB.lookup(prefix: "u4pr")

--- a/Tests/WeaveTests/LocationIntegrationTests.swift
+++ b/Tests/WeaveTests/LocationIntegrationTests.swift
@@ -8,12 +8,12 @@ final class LocationIntegrationTests: XCTestCase {
         let expectation = expectation(description: "location update")
         let manager = PeerManager()
         let peer = try Peer(latitude: 0.0, longitude: 0.0)
-        await manager.add(peer)
+        try await manager.add(peer)
 
         let service = CoreLocationService()
         service.onLocationUpdate = { lat, lon in
             Task {
-                await manager.updateLocation(id: peer.id, latitude: lat, longitude: lon)
+                try? await manager.updateLocation(id: peer.id, latitude: lat, longitude: lon)
                 expectation.fulfill()
             }
         }

--- a/Tests/WeaveTests/PeerManagerTests.swift
+++ b/Tests/WeaveTests/PeerManagerTests.swift
@@ -4,15 +4,15 @@ import Foundation
 @testable import weave
 
 final class PeerManagerTests: XCTestCase {
-    func testFiltersNearbyPeers() async {
+    func testFiltersNearbyPeers() async throws {
 
         let manager = PeerManager()
         let userLocation = try! Peer(latitude: 37.7749, longitude: -122.4194)
         let nearby = try! Peer(latitude: 37.7750, longitude: -122.4195)
         let farAway = try! Peer(latitude: 40.7128, longitude: -74.0060)
 
-        await manager.add(nearby)
-        await manager.add(farAway)
+        try await manager.add(nearby)
+        try await manager.add(farAway)
 
 
         let filteredPeers = await manager.peers(near: userLocation.latitude, longitude: userLocation.longitude, radius: 10.0)
@@ -20,26 +20,26 @@ final class PeerManagerTests: XCTestCase {
         XCTAssertFalse(filteredPeers.contains(farAway))
     }
 
-    func testRemovingPeerUpdatesIndex() async {
+    func testRemovingPeerUpdatesIndex() async throws {
         let manager = PeerManager()
         let peer = try! Peer(latitude: 37.0, longitude: -122.0)
-        await manager.add(peer)
+        try await manager.add(peer)
         XCTAssertEqual(await manager.allPeers().count, 1)
         let prefix = String(peer.geohash.prefix(5))
         XCTAssertEqual(await manager.peers(inGeohash: prefix), [peer])
-        await manager.remove(id: peer.id)
+        try await manager.remove(id: peer.id)
         XCTAssertEqual(await manager.allPeers().count, 0)
         XCTAssertTrue(await manager.peers(inGeohash: prefix).isEmpty)
     }
 
-    func testNearestPeersReturnsSortedResults() async {
+    func testNearestPeersReturnsSortedResults() async throws {
         let manager = PeerManager()
         let origin = try! Peer(latitude: 0.0, longitude: 0.0)
         let nearer = try! Peer(latitude: 0.0, longitude: 0.05) // ~5.5km east
         let near = try! Peer(latitude: 0.0, longitude: 0.1)   // ~11km east
 
-        await manager.add(near)
-        await manager.add(nearer)
+        try await manager.add(near)
+        try await manager.add(nearer)
 
         let results = await manager.nearestPeers(to: origin.latitude, longitude: origin.longitude, limit: 2)
         XCTAssertEqual(results.count, 2)
@@ -48,14 +48,14 @@ final class PeerManagerTests: XCTestCase {
 
     }
 
-    func testNearestPeersRespectsAttributeFilters() async {
+    func testNearestPeersRespectsAttributeFilters() async throws {
         let manager = PeerManager()
         let origin = try! Peer(latitude: 0.0, longitude: 0.0)
         let hikingPeer = try! Peer(latitude: 0.0, longitude: 0.05, attributes: ["hobby": "hiking"])
         let gamingPeer = try! Peer(latitude: 0.0, longitude: 0.02, attributes: ["hobby": "gaming"])
 
-        await manager.add(hikingPeer)
-        await manager.add(gamingPeer)
+        try await manager.add(hikingPeer)
+        try await manager.add(gamingPeer)
 
         let results = await manager.nearestPeers(to: origin.latitude,
                                            longitude: origin.longitude,
@@ -65,7 +65,7 @@ final class PeerManagerTests: XCTestCase {
 
     }
 
-    func testNearestPeersMatchesNaiveImplementation() async {
+    func testNearestPeersMatchesNaiveImplementation() async throws {
         let manager = PeerManager()
         let originLat = 0.0
         let originLon = 0.0
@@ -78,7 +78,7 @@ final class PeerManagerTests: XCTestCase {
             Peer(latitude: -0.2, longitude: 0.0)
         ]
 
-        for peer in peers { await manager.add(peer) }
+        for peer in peers { try await manager.add(peer) }
 
         let optimized = await manager.nearestPeers(to: originLat, longitude: originLon, limit: 5)
 
@@ -101,25 +101,25 @@ final class PeerManagerTests: XCTestCase {
         XCTAssertEqual(optimized, Array(naive.prefix(5)))
     }
 
-    func testAttributeFilteringReturnsMatches() async {
+    func testAttributeFilteringReturnsMatches() async throws {
         let manager = PeerManager()
         let hiker = try! Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "hiking"])
         let gamer = try! Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "gaming"])
 
-        await manager.add(hiker)
-        await manager.add(gamer)
+        try await manager.add(hiker)
+        try await manager.add(gamer)
 
         let results = await manager.peers(near: 0.0, longitude: 0.0, radius: 1.0, matching: ["hobby": "hiking"])
         XCTAssertEqual(results, [hiker])
 
     }
 
-    func testUpdatingPeerLocation() async {
+    func testUpdatingPeerLocation() async throws {
         let manager = PeerManager()
         let peer = try! Peer(latitude: 0.0, longitude: 0.0)
-        await manager.add(peer)
+        try await manager.add(peer)
         let oldPrefix = String(peer.geohash.prefix(5))
-        await manager.updateLocation(id: peer.id, latitude: 1.0, longitude: 1.0)
+        try await manager.updateLocation(id: peer.id, latitude: 1.0, longitude: 1.0)
         let updated = await manager.peer(id: peer.id)!
         XCTAssertEqual(updated.latitude, 1.0)
         XCTAssertEqual(updated.longitude, 1.0)
@@ -130,63 +130,63 @@ final class PeerManagerTests: XCTestCase {
     }
 
 
-    func testUpdatingPeerAttributes() async {
+    func testUpdatingPeerAttributes() async throws {
         let manager = PeerManager()
         let peer = try! Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "gaming"])
-        await manager.add(peer)
+        try await manager.add(peer)
         await manager.updateAttributes(id: peer.id, attributes: ["hobby": "hiking"])
         let updated = await manager.peer(id: peer.id)
         XCTAssertEqual(updated?.attributes["hobby"], "hiking")
     }
 
-    func testUpdatingSingleAttribute() async {
+    func testUpdatingSingleAttribute() async throws {
         let manager = PeerManager()
         let peer = try! Peer(latitude: 0.0, longitude: 0.0)
-        await manager.add(peer)
+        try await manager.add(peer)
         await manager.updateAttribute(id: peer.id, key: "hobby", value: "chess")
         let updated = await manager.peer(id: peer.id)
         XCTAssertEqual(updated?.attributes["hobby"], "chess")
     }
 
-    func testRemovingAttribute() async {
+    func testRemovingAttribute() async throws {
         let manager = PeerManager()
         let peer = try! Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "chess"])
-        await manager.add(peer)
+        try await manager.add(peer)
         await manager.removeAttribute(id: peer.id, key: "hobby")
         let updated = await manager.peer(id: peer.id)
         XCTAssertNil(updated?.attributes["hobby"])
     }
 
-    func testUpdatingPeerAddress() async {
+    func testUpdatingPeerAddress() async throws {
         let manager = PeerManager()
         let peer = try! Peer(address: "1.2.3.4", port: 1000, latitude: 0.0, longitude: 0.0)
-        await manager.add(peer)
+        try await manager.add(peer)
         await manager.updateAddress(id: peer.id, address: "5.6.7.8", port: 2000)
         let updated = await manager.peer(id: peer.id)
         XCTAssertEqual(updated?.address, "5.6.7.8")
         XCTAssertEqual(updated?.port, 2000)
     }
 
-    func testUpdatingPeerName() async {
+    func testUpdatingPeerName() async throws {
         let manager = PeerManager()
         let peer = try! Peer(name: "Old", latitude: 0.0, longitude: 0.0)
-        await manager.add(peer)
+        try await manager.add(peer)
         await manager.updateName(id: peer.id, name: "New")
         let updated = await manager.peer(id: peer.id)
         XCTAssertEqual(updated?.name, "New")
         XCTAssertNotEqual(updated?.lastSeen, peer.lastSeen)
     }
 
-    func testMatchPeersRanksByAttributeScoreThenDistance() async {
+    func testMatchPeersRanksByAttributeScoreThenDistance() async throws {
         let manager = PeerManager()
         let origin = try! Peer(latitude: 0.0, longitude: 0.0, attributes: ["hobby": "hiking"])
         let nearMatch = try! Peer(latitude: 0.0, longitude: 0.05, attributes: ["hobby": "hiking"])
         let farMatch = try! Peer(latitude: 0.0, longitude: 1.0, attributes: ["hobby": "hiking"])
         let nonMatch = try! Peer(latitude: 0.0, longitude: 0.05, attributes: ["hobby": "gaming"])
 
-        await manager.add(nearMatch)
-        await manager.add(farMatch)
-        await manager.add(nonMatch)
+        try await manager.add(nearMatch)
+        try await manager.add(farMatch)
+        try await manager.add(nonMatch)
 
         let matches = await manager.matchPeers(for: origin, radius: 2000.0, limit: 2)
         XCTAssertEqual(matches.count, 2)
@@ -194,37 +194,37 @@ final class PeerManagerTests: XCTestCase {
         XCTAssertEqual(matches[1], farMatch)
     }
 
-    func testPrunesStalePeers() async {
+    func testPrunesStalePeers() async throws {
         let manager = PeerManager()
         let fresh = try! Peer(latitude: 0.0, longitude: 0.0)
         let stale = try! Peer(latitude: 0.0, longitude: 0.0, lastSeen: Date(timeIntervalSinceNow: -7200))
-        await manager.add(fresh)
-        await manager.add(stale)
+        try await manager.add(fresh)
+        try await manager.add(stale)
 
-        await manager.pruneStale(before: Date(timeIntervalSinceNow: -3600))
+        try await manager.pruneStale(before: Date(timeIntervalSinceNow: -3600))
 
         XCTAssertEqual(await manager.allPeers(), [fresh])
     }
 
-    func testPruneStaleRemovesLikedPeers() async {
+    func testPruneStaleRemovesLikedPeers() async throws {
         let manager = PeerManager()
         let fresh = try! Peer(latitude: 0.0, longitude: 0.0)
         let stale = try! Peer(latitude: 0.0, longitude: 0.0, lastSeen: Date(timeIntervalSinceNow: -7200))
-        await manager.add(fresh)
-        await manager.add(stale)
+        try await manager.add(fresh)
+        try await manager.add(stale)
         await manager.like(id: fresh.id)
         await manager.like(id: stale.id)
 
-        await manager.pruneStale(before: Date(timeIntervalSinceNow: -3600))
+        try await manager.pruneStale(before: Date(timeIntervalSinceNow: -3600))
 
         XCTAssertEqual(await manager.likedPeers(), [fresh])
     }
 
-    func testUpdateLastSeenChangesTimestamp() async {
+    func testUpdateLastSeenChangesTimestamp() async throws {
         let manager = PeerManager()
         let oldDate = Date(timeIntervalSince1970: 0)
         let peer = try! Peer(latitude: 0.0, longitude: 0.0, lastSeen: oldDate)
-        await manager.add(peer)
+        try await manager.add(peer)
 
         let newDate = Date(timeIntervalSince1970: 100)
         await manager.updateLastSeen(id: peer.id, at: newDate)
@@ -237,7 +237,7 @@ final class PeerManagerTests: XCTestCase {
         let manager = PeerManager()
         let timestamp = Date(timeIntervalSince1970: 1234)
         let peer = try! Peer(latitude: 1.0, longitude: 2.0, lastSeen: timestamp)
-        await manager.add(peer)
+        try await manager.add(peer)
 
         let tmp = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
@@ -253,7 +253,7 @@ final class PeerManagerTests: XCTestCase {
     func testBlockedPeersPersistThroughStore() async throws {
         let manager = PeerManager()
         let peer = try! Peer(latitude: 0.0, longitude: 0.0)
-        await manager.add(peer)
+        try await manager.add(peer)
         await manager.block(id: peer.id)
 
         let tmp = FileManager.default.temporaryDirectory
@@ -269,10 +269,10 @@ final class PeerManagerTests: XCTestCase {
         XCTAssertEqual(await restored.allPeers(), [peer])
     }
 
-    func testLikedPeersAreReturned() async {
+    func testLikedPeersAreReturned() async throws {
         let manager = PeerManager()
         let peer = try! Peer(latitude: 0.0, longitude: 0.0)
-        await manager.add(peer)
+        try await manager.add(peer)
         await manager.like(id: peer.id)
 
         XCTAssertEqual(await manager.likedPeers(), [peer])
@@ -284,7 +284,7 @@ final class PeerManagerTests: XCTestCase {
     func testLikedPeersPersistThroughStore() async throws {
         let manager = PeerManager()
         let peer = try! Peer(latitude: 0.0, longitude: 0.0)
-        await manager.add(peer)
+        try await manager.add(peer)
         await manager.like(id: peer.id)
 
         let tmp = FileManager.default.temporaryDirectory
@@ -298,13 +298,13 @@ final class PeerManagerTests: XCTestCase {
         XCTAssertEqual(await restored.likedPeers(), [peer])
     }
 
-    func testMutualLikesReturnPeersWhoLikeUser() async {
+    func testMutualLikesReturnPeersWhoLikeUser() async throws {
         let manager = PeerManager()
         let myID = UUID()
         let liker = try! Peer(latitude: 0.0, longitude: 0.0, attributes: ["likes": myID.uuidString])
         let nonLiker = try! Peer(latitude: 0.0, longitude: 0.0)
-        await manager.add(liker)
-        await manager.add(nonLiker)
+        try await manager.add(liker)
+        try await manager.add(nonLiker)
         await manager.like(id: liker.id)
         await manager.like(id: nonLiker.id)
 
@@ -312,12 +312,12 @@ final class PeerManagerTests: XCTestCase {
         XCTAssertEqual(matches, [liker])
     }
 
-    func testBlockedPeersAreExcludedFromQueries() async {
+    func testBlockedPeersAreExcludedFromQueries() async throws {
         let manager = PeerManager()
         let first = try! Peer(latitude: 0.0, longitude: 0.0)
         let second = try! Peer(latitude: 0.0, longitude: 0.0)
-        await manager.add(first)
-        await manager.add(second)
+        try await manager.add(first)
+        try await manager.add(second)
 
         await manager.block(id: second.id)
 
@@ -330,11 +330,11 @@ final class PeerManagerTests: XCTestCase {
         XCTAssertTrue(all.contains(second))
     }
 
-    func testConnectUpdatesLastSeen() async {
+    func testConnectUpdatesLastSeen() async throws {
         let manager = PeerManager()
         let oldDate = Date(timeIntervalSince1970: 0)
         let peer = try! Peer(latitude: 0.0, longitude: 0.0, lastSeen: oldDate)
-        await manager.add(peer)
+        try await manager.add(peer)
 
         let success = await manager.connect(to: peer.id)
         XCTAssertTrue(success)
@@ -342,38 +342,38 @@ final class PeerManagerTests: XCTestCase {
         XCTAssertNotEqual(updated?.lastSeen, oldDate)
     }
 
-    func testConnectFailsForBlockedPeer() async {
+    func testConnectFailsForBlockedPeer() async throws {
         let manager = PeerManager()
         let peer = try! Peer(latitude: 0.0, longitude: 0.0)
-        await manager.add(peer)
+        try await manager.add(peer)
         await manager.block(id: peer.id)
 
         XCTAssertFalse(await manager.connect(to: peer.id))
     }
 
-    func testGeohashEncoding() async {
+    func testGeohashEncoding() async throws {
         let sf = try! Peer(latitude: 37.7749, longitude: -122.4194)
         XCTAssertEqual(sf.geohash, "9q8yyk8y")
     }
 
-    func testPeersInGeohashPrefix() async {
+    func testPeersInGeohashPrefix() async throws {
         let manager = PeerManager()
         let sf = try! Peer(latitude: 37.7749, longitude: -122.4194)
         let la = try! Peer(latitude: 34.0522, longitude: -118.2437)
-        await manager.add(sf)
-        await manager.add(la)
+        try await manager.add(sf)
+        try await manager.add(la)
 
         let prefix = String(sf.geohash.prefix(5))
         let results = await manager.peers(inGeohash: prefix)
         XCTAssertEqual(results, [sf])
     }
 
-    func testPeersInShorterGeohashPrefix() async {
+    func testPeersInShorterGeohashPrefix() async throws {
         let manager = PeerManager()
         let sf = try! Peer(latitude: 37.7749, longitude: -122.4194)
         let la = try! Peer(latitude: 34.0522, longitude: -118.2437)
-        await manager.add(sf)
-        await manager.add(la)
+        try await manager.add(sf)
+        try await manager.add(la)
 
         let shortPrefix = String(sf.geohash.prefix(3))
         let results = await manager.peers(inGeohash: shortPrefix)
@@ -381,12 +381,12 @@ final class PeerManagerTests: XCTestCase {
         XCTAssertFalse(results.contains(la))
     }
 
-    func testPeersInLongerGeohashPrefix() async {
+    func testPeersInLongerGeohashPrefix() async throws {
         let manager = PeerManager()
         let first = try! Peer(latitude: 37.7749, longitude: -122.4194)
         let second = try! Peer(latitude: 37.7750, longitude: -122.4195)
-        await manager.add(first)
-        await manager.add(second)
+        try await manager.add(first)
+        try await manager.add(second)
 
         var prefixLength = 6
         while prefixLength <= first.geohash.count &&
@@ -402,14 +402,14 @@ final class PeerManagerTests: XCTestCase {
     }
 
 
-    func testPeersInGeohashPrefixWithAttributeFilter() async {
+    func testPeersInGeohashPrefixWithAttributeFilter() async throws {
         let manager = PeerManager()
         let sfHiker = try! Peer(latitude: 37.7749, longitude: -122.4194, attributes: ["hobby": "hiking"])
         let sfBaker = try! Peer(latitude: 37.7750, longitude: -122.4195, attributes: ["hobby": "baking"])
         let laHiker = try! Peer(latitude: 34.0522, longitude: -118.2437, attributes: ["hobby": "hiking"])
-        await manager.add(sfHiker)
-        await manager.add(sfBaker)
-        await manager.add(laHiker)
+        try await manager.add(sfHiker)
+        try await manager.add(sfBaker)
+        try await manager.add(laHiker)
 
         let prefix = String(sfHiker.geohash.prefix(5))
         let results = await manager.peers(inGeohash: prefix, matching: ["hobby": "hiking"])
@@ -417,15 +417,15 @@ final class PeerManagerTests: XCTestCase {
     }
 
 
-    func testRecentPeersReturnsMostRecentFirst() async {
+    func testRecentPeersReturnsMostRecentFirst() async throws {
         let manager = PeerManager()
         let older = try! Peer(latitude: 0.0, longitude: 0.0, lastSeen: Date(timeIntervalSinceNow: -3600))
         let newer = try! Peer(latitude: 0.0, longitude: 0.0)
         let blocked = try! Peer(latitude: 0.0, longitude: 0.0)
 
-        await manager.add(older)
-        await manager.add(newer)
-        await manager.add(blocked)
+        try await manager.add(older)
+        try await manager.add(newer)
+        try await manager.add(blocked)
         await manager.block(id: blocked.id)
 
         let results = await manager.recentPeers(limit: 5)
@@ -434,14 +434,14 @@ final class PeerManagerTests: XCTestCase {
     }
 
     /// Ensures the manager handles concurrent access without crashing or losing peers.
-    func testConcurrentAccess() async {
+    func testConcurrentAccess() async throws {
         let manager = PeerManager()
 
         await withTaskGroup(of: Void.self) { group in
             for _ in 0..<100 {
                 group.addTask {
                     let peer = try! Peer(latitude: 0.0, longitude: 0.0)
-                    await manager.add(peer)
+                    try? await manager.add(peer)
                 }
             }
         }
@@ -450,14 +450,14 @@ final class PeerManagerTests: XCTestCase {
     }
 
     /// Invokes `nearestPeers` while other tasks mutate the manager to ensure thread safety.
-    func testNearestPeersThreadSafetyDuringMutation() async {
+    func testNearestPeersThreadSafetyDuringMutation() async throws {
         let manager = PeerManager()
 
         await withTaskGroup(of: Void.self) { group in
             for _ in 0..<100 {
                 group.addTask {
                     let peer = try! Peer(latitude: 0.0, longitude: 0.0)
-                    await manager.add(peer)
+                    try? await manager.add(peer)
                 }
 
                 group.addTask {
@@ -470,28 +470,28 @@ final class PeerManagerTests: XCTestCase {
         XCTAssertLessThanOrEqual(await manager.nearestPeers(to: 0.0, longitude: 0.0, limit: 5).count, 5)
     }
 
-    func testReaddingPeerReindexesGeohash() async {
+    func testReaddingPeerReindexesGeohash() async throws {
         let manager = PeerManager()
         let id = UUID()
         let first = try! Peer(id: id, latitude: 37.0, longitude: -122.0)
-        await manager.add(first)
+        try await manager.add(first)
         let oldHash = first.geohash
 
         let second = try! Peer(id: id, latitude: 40.0, longitude: -74.0)
-        await manager.add(second)
+        try await manager.add(second)
         let newHash = second.geohash
 
         XCTAssertTrue(await manager.peers(inGeohash: oldHash).isEmpty)
         XCTAssertEqual(await manager.peers(inGeohash: newHash), [second])
     }
 
-    func testPeersDiscoveredAcrossManagersViaDHT() async {
+    func testPeersDiscoveredAcrossManagersViaDHT() async throws {
         let dht = InMemoryDHT()
         let nodeA = PeerManager(dht: dht)
         let nodeB = PeerManager(dht: dht)
 
         let remote = try! Peer(latitude: 10.0, longitude: 10.0)
-        await nodeA.add(remote)
+        try await nodeA.add(remote)
 
         let prefix = String(remote.geohash.prefix(5))
         XCTAssertTrue(await nodeB.peers(inGeohash: prefix).isEmpty)
@@ -500,7 +500,7 @@ final class PeerManagerTests: XCTestCase {
         XCTAssertTrue(discovered.contains(remote.id))
 
         if let fetched = await nodeA.peer(id: remote.id) {
-            await nodeB.add(fetched)
+            try await nodeB.add(fetched)
         }
 
         let results = await nodeB.peers(inGeohash: prefix)


### PR DESCRIPTION
## Summary
- add `DHTError` and make DHT `store`/`remove` throw on encode or put failures with debug logging
- propagate DHT write failures through `PeerManager` and update callers
- adjust location service, main demo and tests for new throwing APIs

## Testing
- `swift test` *(failed: Failed to clone repository https://github.com/libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68901e52c524832b91550f21e379c676