### PR TITLE
Handle IPv6 and DNS multiaddr

### DIFF
--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -1,5 +1,32 @@
 import Foundation
 import Crypto
+#if canImport(Glibc)
+import Glibc
+#elseif canImport(Darwin)
+import Darwin
+#endif
+
+/// Build a multiaddr string for the given address and port. The function
+/// attempts to detect whether the address represents an IPv4, IPv6 or DNS
+/// hostname and prefixes the multiaddr accordingly.
+///
+/// - Parameters:
+///   - address: The peer's address in string form.
+///   - port: The peer's port number.
+/// - Returns: A multiaddr string such as "/ip4/1.2.3.4/tcp/4001".
+func multiaddrString(for address: String, port: UInt16) -> String {
+    var ipv4 = in_addr()
+    var ipv6 = in6_addr()
+    let prefix: String
+    if address.withCString({ inet_pton(AF_INET, $0, &ipv4) }) == 1 {
+        prefix = "ip4"
+    } else if address.withCString({ inet_pton(AF_INET6, $0, &ipv6) }) == 1 {
+        prefix = "ip6"
+    } else {
+        prefix = "dns"
+    }
+    return "/\(prefix)/\(address)/tcp/\(port)"
+}
 
 #if canImport(LibP2P)
 import LibP2P
@@ -55,7 +82,8 @@ struct LibP2PHost: LibP2PHosting {
         guard let address = peer.address, let port = peer.port else {
             throw HostError.missingPeerAddress
         }
-        let addr = try Multiaddr("/ip4/\(address)/tcp/\(port)")
+        let maddr = multiaddrString(for: address, port: port)
+        let addr = try Multiaddr(maddr)
         let stream = try host.openStream(to: addr).wait()
         return HostStream(peer: peer, stream: stream)
     }

--- a/Tests/WeaveTests/MultiaddrBuilderTests.swift
+++ b/Tests/WeaveTests/MultiaddrBuilderTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import weave
+
+final class MultiaddrBuilderTests: XCTestCase {
+    func testIPv6AddressBuildsCorrectMultiaddr() {
+        let addr = multiaddrString(for: "2001:db8::1", port: 3030)
+        XCTAssertEqual(addr, "/ip6/2001:db8::1/tcp/3030")
+    }
+
+    func testHostnameBuildsDNSMultiaddr() {
+        let addr = multiaddrString(for: "example.com", port: 8080)
+        XCTAssertEqual(addr, "/dns/example.com/tcp/8080")
+    }
+}


### PR DESCRIPTION
## Summary
- detect peer address type and build appropriate multiaddr
- test building of IPv6 and DNS multiaddrs

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68901e53b6b8832ba62354115e07c22e