### PR TITLE
Propagate errors from DHT bootstrap

### DIFF
--- a/Sources/DHT.swift
+++ b/Sources/DHT.swift
@@ -90,10 +90,9 @@ public actor LibP2PDHT: DHT {
     }
 
     /// Connects this DHT's host to another peer in the network.
-    public func bootstrap(to address: String) {
-        if let addr = try? Multiaddr(address) {
-            _ = try? host.bootstrap(to: addr).wait()
-        }
+    public func bootstrap(to address: String) throws {
+        let addr = try Multiaddr(address)
+        _ = try host.bootstrap(to: addr).wait()
     }
 
     /// The multiaddresses this host is currently listening on.

--- a/Tests/WeaveTests/LibP2PIntegrationTests.swift
+++ b/Tests/WeaveTests/LibP2PIntegrationTests.swift
@@ -6,8 +6,8 @@ final class LibP2PIntegrationTests: XCTestCase {
         let dhtA = try LibP2PDHT()
         let dhtB = try LibP2PDHT()
         // Connect the DHT instances so stored values propagate
-        for addr in dhtA.listenAddresses { dhtB.bootstrap(to: addr) }
-        for addr in dhtB.listenAddresses { dhtA.bootstrap(to: addr) }
+        for addr in await dhtA.listenAddresses { try await dhtB.bootstrap(to: addr) }
+        for addr in await dhtB.listenAddresses { try await dhtA.bootstrap(to: addr) }
 
         let peerID = UUID()
         try await dhtA.store(peerID: peerID, geohash: "u4pruydqqvj")


### PR DESCRIPTION
## Summary
- make `LibP2PDHT.bootstrap` throw instead of swallowing errors
- update integration tests to await and handle thrown bootstrap errors

## Testing
- `swift test -q` *(fails: Failed to clone repository https://github.com/libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689161dfdfdc832b9ccbea52e1baf48d