### PR TITLE
Validate coordinates on update

### DIFF
--- a/Sources/PeerManager.swift
+++ b/Sources/PeerManager.swift
@@ -91,6 +91,14 @@ actor PeerManager {
     /// Updates a peer's geographic location if it exists in the manager.
     func updateLocation(id: UUID, latitude: Double, longitude: Double) async throws {
         guard var peer = peerIndex[id] else { return }
+
+        guard (-90.0...90.0).contains(latitude) else {
+            throw Peer.PeerError.invalidLatitude(latitude)
+        }
+        guard (-180.0...180.0).contains(longitude) else {
+            throw Peer.PeerError.invalidLongitude(longitude)
+        }
+
         let oldKey = peer.geohash
         peer.latitude = latitude
         peer.longitude = longitude

--- a/Tests/WeaveTests/PeerManagerTests.swift
+++ b/Tests/WeaveTests/PeerManagerTests.swift
@@ -129,6 +129,36 @@ final class PeerManagerTests: XCTestCase {
         XCTAssertFalse(await manager.peers(inGeohash: oldPrefix).contains(updated))
     }
 
+    func testUpdateLocationThrowsForInvalidLatitude() async throws {
+        let manager = PeerManager()
+        let peer = try! Peer(latitude: 0.0, longitude: 0.0)
+        try await manager.add(peer)
+
+        do {
+            try await manager.updateLocation(id: peer.id, latitude: 100.0, longitude: 0.0)
+            XCTFail("Expected invalid latitude error")
+        } catch Peer.PeerError.invalidLatitude(let value) {
+            XCTAssertEqual(value, 100.0)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testUpdateLocationThrowsForInvalidLongitude() async throws {
+        let manager = PeerManager()
+        let peer = try! Peer(latitude: 0.0, longitude: 0.0)
+        try await manager.add(peer)
+
+        do {
+            try await manager.updateLocation(id: peer.id, latitude: 0.0, longitude: 200.0)
+            XCTFail("Expected invalid longitude error")
+        } catch Peer.PeerError.invalidLongitude(let value) {
+            XCTAssertEqual(value, 200.0)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
 
     func testUpdatingPeerAttributes() async throws {
         let manager = PeerManager()


### PR DESCRIPTION
## Summary
- validate latitude and longitude ranges in `PeerManager.updateLocation`
- test valid and invalid location updates

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689161e0e468832bb4f19778b35e6f5d