### PR TITLE
Introduce structured logging with swift-log

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,8 @@ let package = Package(
         // Swift libp2p implementation providing the `Host` we wrap in
         // `LibP2PNode`.
         .package(url: "https://github.com/libp2p/swift-libp2p.git", branch: "main"),
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "2.7.0")
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "2.7.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.2")
     ],
     targets: [
         // Targets define modules or test suites.
@@ -21,7 +22,8 @@ let package = Package(
             dependencies: [
                 .product(name: "Crypto", package: "swift-crypto"),
                 // Once released, this product will expose the libp2p host implementation.
-                .product(name: "LibP2P", package: "swift-libp2p")
+                .product(name: "LibP2P", package: "swift-libp2p"),
+                .product(name: "Logging", package: "swift-log")
             ]),
         .testTarget(
             name: "WeaveTests",

--- a/Sources/DHT.swift
+++ b/Sources/DHT.swift
@@ -1,5 +1,6 @@
 import Foundation
 import LibP2P
+import Logging
 
 /// Errors that can occur when writing values to the DHT.
 public enum DHTError: Error {
@@ -68,6 +69,8 @@ public actor LibP2PDHT: DHT {
     private let host: Host
     /// Kademlia DHT service provided by the host.
     private let kademlia: KademliaDHT
+    /// Logger for reporting DHT operations.
+    private let logger = Logger(label: "DHT")
 
     /// Creates a new libp2p backed DHT. A host may be provided when
     /// integrating with an existing libp2p node. If omitted a fresh host is
@@ -110,13 +113,13 @@ public actor LibP2PDHT: DHT {
             do {
                 data = try JSONEncoder().encode(Array(set))
             } catch {
-                print("[DHT] Failed to encode peer set for key \(key): \(error)")
+                logger.error("Failed to encode peer set for key \(key): \(error)")
                 throw DHTError.encodingFailed(error)
             }
             do {
                 try await kademlia.put(key: key, value: data)
             } catch {
-                print("[DHT] Failed to put peer set for key \(key): \(error)")
+                logger.error("Failed to put peer set for key \(key): \(error)")
                 throw DHTError.putFailed(error)
             }
         }
@@ -131,13 +134,13 @@ public actor LibP2PDHT: DHT {
             do {
                 data = try JSONEncoder().encode(Array(set))
             } catch {
-                print("[DHT] Failed to encode peer set for key \(key): \(error)")
+                logger.error("Failed to encode peer set for key \(key): \(error)")
                 throw DHTError.encodingFailed(error)
             }
             do {
                 try await kademlia.put(key: key, value: data)
             } catch {
-                print("[DHT] Failed to put peer set for key \(key): \(error)")
+                logger.error("Failed to put peer set for key \(key): \(error)")
                 throw DHTError.putFailed(error)
             }
         }

--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Crypto
+import Logging
 #if canImport(Glibc)
 import Glibc
 #elseif canImport(Darwin)
@@ -176,6 +177,8 @@ actor LibP2PNode {
     private var host: LibP2PHosting?
     /// Callback invoked for each successfully decoded inbound message.
     private var messageHandler: (@Sendable (Message, Peer) -> Void)?
+    /// Logger instance for recording node events.
+    private let logger = Logger(label: "LibP2PNode")
 
     init(bootstrapPeers: [String] = [],
          hostBuilder: @escaping () throws -> LibP2PHosting = {
@@ -203,7 +206,7 @@ actor LibP2PNode {
                 try host.bootstrap(peers: bootstrapPeers)
             }
         } catch {
-            print("Failed to start libp2p host: \(error)")
+            logger.error("Failed to start libp2p host: \(error)")
             throw error
         }
     }
@@ -214,7 +217,7 @@ actor LibP2PNode {
             do {
                 try host.stop()
             } catch {
-                print("Failed to stop libp2p host: \(error)")
+                logger.error("Failed to stop libp2p host: \(error)")
             }
         }
         host = nil
@@ -241,7 +244,7 @@ actor LibP2PNode {
         do {
             try stream.write(data)
         } catch {
-            print("Failed to write message to stream: \(error)")
+            logger.error("Failed to write message to stream: \(error)")
             throw error
         }
     }
@@ -299,6 +302,9 @@ actor P2PNode {
     /// Handler invoked when decryption or decoding fails.
     private var errorHandler: (@Sendable (Error, Peer) -> Void)?
 
+    /// Logger instance for high-level node events.
+    private let logger = Logger(label: "P2PNode")
+
 
     init(bootstrapPeers: [String] = [],
          hostBuilder: @escaping () throws -> LibP2PHosting = {
@@ -329,7 +335,7 @@ actor P2PNode {
         do {
             try host.start()
         } catch {
-            print("Failed to start host: \(error)")
+            logger.error("Failed to start host: \(error)")
             throw error
         }
 
@@ -337,14 +343,14 @@ actor P2PNode {
             do {
                 try host.bootstrap(peers: bootstrapPeers)
             } catch {
-                print("Failed to bootstrap peers: \(error)")
+                logger.warning("Failed to bootstrap peers: \(error)")
             }
         }
 
         do {
             try host.enableNAT()
         } catch {
-            print("Failed to enable NAT: \(error)")
+            logger.warning("Failed to enable NAT: \(error)")
         }
 
         isRunning = true
@@ -357,7 +363,7 @@ actor P2PNode {
             do {
                 try host.stop()
             } catch {
-                print("Failed to stop host: \(error)")
+                logger.error("Failed to stop host: \(error)")
             }
         }
         host = nil
@@ -394,7 +400,7 @@ actor P2PNode {
         do {
             try stream.write(encrypted)
         } catch {
-            print("Failed to send encrypted message: \(error)")
+            logger.error("Failed to send encrypted message: \(error)")
             throw error
         }
     }
@@ -481,7 +487,7 @@ actor P2PNode {
             if let errorHandler {
                 errorHandler(error, peer)
             } else {
-                print("Failed to handle incoming data from \(peer.id): \(error)")
+                logger.error("Failed to handle incoming data from \(peer.id): \(error)")
             }
         }
     }

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -1,8 +1,12 @@
 import Foundation
+import Logging
 
 @main
 struct Main {
     static func main() async {
+        LoggingSystem.bootstrap(StreamLogHandler.standardError)
+        let logger = Logger(label: "Main")
+
         // Demonstration of using the PeerManager alongside a libp2p-backed
         // networking node. The node bootstraps to a well known peer so it can
         // discover the rest of the network as soon as the app launches.
@@ -43,65 +47,65 @@ struct Main {
         // match) and demonstrate attribute filtering.
         let prefix = String(movingPeer.geohash.prefix(5))
         let geohashPeers = await manager.peers(inGeohash: prefix)
-        print("Peers in geohash prefix \(prefix): \(geohashPeers.count)")
+        logger.info("Peers in geohash prefix \(prefix): \(geohashPeers.count)")
         let hikingInPrefix = await manager.peers(inGeohash: prefix, matching: ["hobby": "hiking"])
-        print("Hiking peers in geohash prefix \(prefix): \(hikingInPrefix.count)")
+        logger.info("Hiking peers in geohash prefix \(prefix): \(hikingInPrefix.count)")
 
         var nearbyPeers = await manager.peers(near: selfLat, longitude: selfLon, radius: 5000.0)
-        print("Peers within 5000km: \(nearbyPeers.count)")
+        logger.info("Peers within 5000km: \(nearbyPeers.count)")
 
         // Connect to the moving peer and refresh its last-seen timestamp
         if await manager.connect(to: movingPeer.id) {
-            print("Connected to moving peer")
+            logger.info("Connected to moving peer")
         }
 
         // Like and then unlike the moving peer
         await manager.like(id: movingPeer.id)
-        print("Liked peers: \(await manager.likedPeers().count)")
+        logger.info("Liked peers: \(await manager.likedPeers().count)")
         await manager.unlike(id: movingPeer.id)
-        print("Liked peers after unlike: \(await manager.likedPeers().count)")
+        logger.info("Liked peers after unlike: \(await manager.likedPeers().count)")
         // Like again to demonstrate mutual match detection
         await manager.like(id: movingPeer.id)
         let mutual = await manager.mutualLikes(for: me.id)
-        print("Mutual matches: \(mutual.count)")
+        logger.info("Mutual matches: \(mutual.count)")
 
         // Block the Los Angeles peer
         await manager.block(id: laPeer.id)
         nearbyPeers = await manager.peers(near: selfLat, longitude: selfLon, radius: 5000.0)
-        print("Peers after blocking LA user: \(nearbyPeers.count)")
+        logger.info("Peers after blocking LA user: \(nearbyPeers.count)")
 
         // Update the peer's location to New York
         try? await manager.updateLocation(id: movingPeer.id, latitude: 40.7128, longitude: -74.0060)
         nearbyPeers = await manager.peers(near: selfLat, longitude: selfLon, radius: 5.0)
-        print("Nearby peers after move: \(nearbyPeers.count)")
+        logger.info("Nearby peers after move: \(nearbyPeers.count)")
 
         // Update the peer's network address
         await manager.updateAddress(id: movingPeer.id, address: "203.0.113.1", port: 8080)
         if let updated = await manager.peer(id: movingPeer.id) {
-            print("Peer network address: \(updated.address ?? "n/a"):\(updated.port ?? 0)")
+            logger.info("Peer network address: \(updated.address ?? "n/a"):\(updated.port ?? 0)")
         }
 
         // Change the peer's display name
         await manager.updateName(id: movingPeer.id, name: "Traveler")
-        print("Peer name after update: \(await manager.peer(id: movingPeer.id)?.name ?? "none")")
+        logger.info("Peer name after update: \(await manager.peer(id: movingPeer.id)?.name ?? "none")")
 
         // Update a single attribute and then remove it
         await manager.updateAttribute(id: movingPeer.id, key: "hobby", value: "climbing")
-        print("Updated hobby: \(await manager.peer(id: movingPeer.id)?.attributes["hobby"] ?? "none")")
+        logger.info("Updated hobby: \(await manager.peer(id: movingPeer.id)?.attributes["hobby"] ?? "none")")
         await manager.removeAttribute(id: movingPeer.id, key: "hobby")
-        print("Hobby after removal: \(await manager.peer(id: movingPeer.id)?.attributes["hobby"] ?? "none")")
+        logger.info("Hobby after removal: \(await manager.peer(id: movingPeer.id)?.attributes["hobby"] ?? "none")")
 
         let hikers = await manager.peers(near: selfLat, longitude: selfLon, radius: 5000.0, matching: ["hobby": "hiking"])
-        print("Hikers within 5000km: \(hikers.count)")
+        logger.info("Hikers within 5000km: \(hikers.count)")
 
         let matches = await manager.matchPeers(for: me, radius: 5000.0, limit: 5)
-        print("Top matches by hobby within 5000km: \(matches.count)")
+        logger.info("Top matches by hobby within 5000km: \(matches.count)")
 
         let nearestHikers = await manager.nearestPeers(to: selfLat,
                                                  longitude: selfLon,
                                                  limit: 3,
                                                  matching: ["hobby": "hiking"])
-        print("Nearest hikers: \(nearestHikers.count)")
+        logger.info("Nearest hikers: \(nearestHikers.count)")
 
         // Persist peers to disk and load them back
         let storeURL = URL(fileURLWithPath: "/tmp/peers.json")
@@ -109,20 +113,20 @@ struct Main {
         try? await manager.save(to: store)
         let restored = PeerManager()
         try? await restored.load(from: store)
-        print("Restored \(await restored.allPeers().count) peer(s) from disk (blocked peers excluded)")
+        logger.info("Restored \(await restored.allPeers().count) peer(s) from disk (blocked peers excluded)")
         await restored.unblock(id: laPeer.id)
-        print("After unblocking LA user post-restore: \(await restored.allPeers().count) peer(s)")
+        logger.info("After unblocking LA user post-restore: \(await restored.allPeers().count) peer(s)")
 
         // Demonstrate pruning stale peers
         let stalePeer = try! Peer(latitude: 35.0, longitude: -120.0, lastSeen: Date(timeIntervalSinceNow: -7200))
         try? await manager.add(stalePeer)
-        print("Total peers before pruning: \(await manager.allPeers().count)")
+        logger.info("Total peers before pruning: \(await manager.allPeers().count)")
         try? await manager.pruneStale(before: Date(timeIntervalSinceNow: -3600))
-        print("Peers after pruning stale entries: \(await manager.allPeers().count)")
+        logger.info("Peers after pruning stale entries: \(await manager.allPeers().count)")
 
         // Fetch the most recently seen peers
         let recent = await manager.recentPeers(limit: 2)
-        print("Most recently seen peers: \(recent.count)")
+        logger.info("Most recently seen peers: \(recent.count)")
 
         await node.stop()
     }

--- a/Tests/WeaveTests/Logging.swift
+++ b/Tests/WeaveTests/Logging.swift
@@ -1,0 +1,6 @@
+import Logging
+
+// Suppress log output during tests.
+let _ = {
+    LoggingSystem.bootstrap(SwiftLogNoOpLogHandler.init)
+}()


### PR DESCRIPTION
## Summary
- add `swift-log` as a dependency and expose its `Logging` product
- switch `P2PNode`, `LibP2PDHT`, and the main entry point to use `Logger` instead of `print`
- silence log output during tests

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689161e0fd48832ba7963ab2c8136a12