### PR TITLE
Add IPv4 multiaddr builder test

### DIFF
--- a/Tests/WeaveTests/MultiaddrBuilderTests.swift
+++ b/Tests/WeaveTests/MultiaddrBuilderTests.swift
@@ -2,6 +2,11 @@ import XCTest
 @testable import weave
 
 final class MultiaddrBuilderTests: XCTestCase {
+    func testIPv4AddressBuildsCorrectMultiaddr() {
+        let addr = multiaddrString(for: "1.2.3.4", port: 4001)
+        XCTAssertEqual(addr, "/ip4/1.2.3.4/tcp/4001")
+    }
+
     func testIPv6AddressBuildsCorrectMultiaddr() {
         let addr = multiaddrString(for: "2001:db8::1", port: 3030)
         XCTAssertEqual(addr, "/ip6/2001:db8::1/tcp/3030")


### PR DESCRIPTION
## Summary
- test IPv4 addresses build the correct multiaddr

## Testing
- `swift test` *(fails: unable to clone repository https://github.com/libp2p/swift-libp2p.git)*

------
https://chatgpt.com/codex/tasks/task_e_689161e20800832b926af1817764bc1a