### PR TITLE
Mark host builder closures as Sendable

### DIFF
--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -181,7 +181,7 @@ actor LibP2PNode {
     private let logger = Logger(label: "LibP2PNode")
 
     init(bootstrapPeers: [String] = [],
-         hostBuilder: @escaping () throws -> LibP2PHosting = {
+         hostBuilder: @escaping @Sendable () throws -> LibP2PHosting = { @Sendable in
             return try LibP2PHost()
          }) {
         self.bootstrapPeers = bootstrapPeers
@@ -307,7 +307,7 @@ actor P2PNode {
 
 
     init(bootstrapPeers: [String] = [],
-         hostBuilder: @escaping () throws -> LibP2PHosting = {
+         hostBuilder: @escaping @Sendable () throws -> LibP2PHosting = { @Sendable in
             return try LibP2PHost()
          },
          keyDerivation: @escaping (Curve25519.KeyAgreement.PrivateKey, Data) throws -> SymmetricKey = Encryption.deriveSharedSecret) {


### PR DESCRIPTION
## Summary
- ensure LibP2PNode and P2PNode host builders are sendable

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/swift-libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6892a6bcbfd8832ba54033882313b5c4