### PR TITLE
Handle missing sealed box data before writing

### DIFF
--- a/Sources/PeerStore.swift
+++ b/Sources/PeerStore.swift
@@ -135,7 +135,10 @@ struct PeerStore {
             at: url.deletingLastPathComponent(),
             withIntermediateDirectories: true
         )
-        try sealedBox.combined.write(to: url, options: .atomic)
+        guard let combined = sealedBox.combined else {
+            throw StoreError.encryptionFailed
+        }
+        try combined.write(to: url, options: .atomic)
     }
 
     /// Loads peers and blocked/liked IDs from disk. Returns empty collections if the


### PR DESCRIPTION
## Summary
- Guard against nil sealedBox.combined before writing encrypted data

## Testing
- `swift test` *(fails: unable to access https://github.com/swift-libp2p/swift-libp2p.git/)*

------
https://chatgpt.com/codex/tasks/task_e_6892a6bae448832ba1f2a9c503eaae50