### PR TITLE
refactor: update libp2p API

### DIFF
--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -31,24 +31,31 @@ func multiaddrString(for address: String, port: UInt16) -> String {
 
 #if canImport(LibP2P)
 import LibP2P
+import NIO
 
-/// Concrete implementation backed by the real `swift-libp2p` `Host`.
+/// Concrete implementation backed by the real `swift-libp2p` `Swarm`.
 struct LibP2PHost: LibP2PHosting {
-    /// Underlying libp2p host instance.
-    private let host: Host
+    /// Manages transports for the swarm.
+    private let transportManager: TransportManager
+    /// Libp2p swarm responsible for dialing and listening.
+    private let swarm: Swarm
+    /// Event loop group driving the networking stack.
+    private let group: EventLoopGroup
 
     init() throws {
-        // Build a default host using libp2p's builder which configures
-        // transports, muxers and security implementations suitable for most
-        // use cases.
-        self.host = try HostBuilder().build()
+        // The new libp2p API separates transport configuration from the swarm
+        // that manages connections. A basic transport manager and swarm are
+        // created here for general usage.
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        self.group = group
+        self.transportManager = TransportManager(group: group)
+        self.swarm = try Swarm(transportManager: transportManager)
     }
 
     /// Start listening for connections.
     func start() throws {
-        // Many libp2p operations return an EventLoopFuture. Waiting here keeps
-        // the abstraction simple for callers.
-        try host.start().wait()
+        // Starting the transport manager brings up the underlying listeners.
+        try transportManager.start().wait()
     }
 
     /// Connect to a list of bootstrap peers so the node can discover the wider
@@ -56,19 +63,14 @@ struct LibP2PHost: LibP2PHosting {
     func bootstrap(peers: [String]) throws {
         for address in peers {
             let addr = try Multiaddr(address)
-            try host.bootstrap(to: addr).wait()
+            _ = try swarm.dial(addr).wait()
         }
-    }
-
-    /// Enable NAT traversal via AutoNAT/UPnP so the node becomes reachable from
-    /// outside the local network.
-    func enableNAT() throws {
-        try host.enableNAT().wait()
     }
 
     /// Shut down the host and release any associated resources.
     func stop() throws {
-        try host.stop().wait()
+        try transportManager.stop().wait()
+        try group.syncShutdownGracefully()
     }
 
     enum HostError: Error {
@@ -85,13 +87,13 @@ struct LibP2PHost: LibP2PHosting {
         }
         let maddr = multiaddrString(for: address, port: port)
         let addr = try Multiaddr(maddr)
-        let stream = try host.openStream(to: addr).wait()
+        let stream = try swarm.dial(addr).wait()
         return HostStream(peer: peer, stream: stream)
     }
 
     /// Register a handler for incoming streams initiated by remote peers.
     func setStreamHandler(_ handler: @escaping (LibP2PStream) -> Void) {
-        host.setStreamHandler { stream in
+        swarm.setStreamHandler { stream in
             // Derive a minimal `Peer` representation from the remote
             // connection. The remote address is extracted if available, but any
             // location information is left at defaults.
@@ -106,7 +108,7 @@ struct LibP2PHost: LibP2PHosting {
 
     /// The multiaddresses the underlying host is listening on.
     var listenAddresses: [String] {
-        host.listenAddresses.map { $0.description }
+        swarm.listenAddresses.map { $0.description }
     }
 }
 
@@ -146,8 +148,6 @@ protocol LibP2PHosting {
     func start() throws
     /// Connect to a set of bootstrap peers to join the network.
     func bootstrap(peers: [String]) throws
-    /// Enable NAT traversal so the node is reachable from the public internet.
-    func enableNAT() throws
     /// Shut down the host and release any resources.
     func stop() throws
     /// Open a new stream to the given peer.
@@ -321,8 +321,8 @@ actor P2PNode {
 
     }
 
-    /// Starts the networking stack by creating a libp2p host, performing
-    /// bootstrap against known peers and enabling NAT traversal.
+    /// Starts the networking stack by creating a libp2p host and performing
+    /// bootstrap against known peers.
     func start() throws {
         guard !isRunning else { return }
 
@@ -345,12 +345,6 @@ actor P2PNode {
             } catch {
                 logger.warning("Failed to bootstrap peers: \(error)")
             }
-        }
-
-        do {
-            try host.enableNAT()
-        } catch {
-            logger.warning("Failed to enable NAT: \(error)")
         }
 
         isRunning = true

--- a/Tests/WeaveTests/EncryptionTests.swift
+++ b/Tests/WeaveTests/EncryptionTests.swift
@@ -63,7 +63,6 @@ final class EncryptionTests: XCTestCase {
 
             func start() throws {}
             func bootstrap(peers: [String]) throws {}
-            func enableNAT() throws {}
             func stop() throws {}
 
             func openStream(to peer: Peer) throws -> LibP2PStream {

--- a/Tests/WeaveTests/LibP2PNodeWrapperTests.swift
+++ b/Tests/WeaveTests/LibP2PNodeWrapperTests.swift
@@ -10,7 +10,6 @@ final class LibP2PNodeWrapperTests: XCTestCase {
 
         func start() throws { started = true }
         func bootstrap(peers: [String]) throws { bootstrapped = peers }
-        func enableNAT() throws {}
         func stop() throws {}
         func openStream(to peer: Peer) throws -> LibP2PStream { NoopLibP2PStream(peer: peer) }
         func setStreamHandler(_ handler: @escaping (LibP2PStream) -> Void) { self.handler = handler }
@@ -49,7 +48,6 @@ final class LibP2PNodeWrapperTests: XCTestCase {
 
         func start() throws {}
         func bootstrap(peers: [String]) throws {}
-        func enableNAT() throws {}
         func stop() throws {}
 
         func openStream(to peer: Peer) throws -> LibP2PStream {

--- a/Tests/WeaveTests/P2PNodeTests.swift
+++ b/Tests/WeaveTests/P2PNodeTests.swift
@@ -6,18 +6,16 @@ final class P2PNodeTests: XCTestCase {
     final class MockHost: LibP2PHosting {
         var startCount = 0
         var bootstrapped: [String] = []
-        var natEnabled = false
         var stopCount = 0
 
         func start() throws { startCount += 1 }
         func bootstrap(peers: [String]) throws { bootstrapped = peers }
-        func enableNAT() throws { natEnabled = true }
         func stop() throws { stopCount += 1 }
         func openStream(to peer: Peer) throws -> LibP2PStream { NoopLibP2PStream(peer: peer) }
         func setStreamHandler(_ handler: @escaping (LibP2PStream) -> Void) {}
     }
 
-    func testStartBootstrapsAndEnablesNAT() async throws {
+    func testStartBootstrapsHost() async throws {
         let mock = MockHost()
         let node = P2PNode(bootstrapPeers: ["1.2.3.4:4001"], hostBuilder: { mock })
 
@@ -27,7 +25,6 @@ final class P2PNodeTests: XCTestCase {
         XCTAssertTrue(await node.isRunning)
         XCTAssertEqual(mock.startCount, 1)
         XCTAssertEqual(mock.bootstrapped, ["1.2.3.4:4001"])
-        XCTAssertTrue(mock.natEnabled)
     }
 
     func testStopShutsDownHost() async throws {
@@ -177,7 +174,6 @@ final class P2PNodeTests: XCTestCase {
 
         func start() throws {}
         func bootstrap(peers: [String]) throws {}
-        func enableNAT() throws {}
         func stop() throws {}
 
         func openStream(to peer: Peer) throws -> LibP2PStream {


### PR DESCRIPTION
## Summary
- rebuild LibP2P host initialization around `TransportManager` and `Swarm`
- drop deprecated NAT enable call and adjust host lifecycle
- clean up tests for updated host abstraction

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/swift-libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6892a6bbb8d8832ba2db70727665f1e5