### PR TITLE
Use onRead for inbound stream data

### DIFF
--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -129,7 +129,12 @@ private final class HostStream: LibP2PStream {
     }
 
     func setDataHandler(_ handler: @escaping (Data) -> Void) {
-        stream.setDataHandler(handler)
+        stream.onRead { buffer in
+            var buffer = buffer
+            if let data = buffer.readData(length: buffer.readableBytes) {
+                handler(data)
+            }
+        }
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- Update HostStream to use `onRead` for inbound bytes and forward them as Data

## Testing
- `swift test` *(fails: unable to clone https://github.com/swift-libp2p/swift-libp2p.git, CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_6892ab13ca1c832ba5ba16daf99ce38a