### PR TITLE
Use new LibP2P stream read handler

### DIFF
--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -134,7 +134,7 @@ private final class HostStream: LibP2PStream {
     }
 
     func setDataHandler(_ handler: @escaping (Data) -> Void) {
-        stream.onRead { buffer in
+        stream.setReadHandler { buffer in
             var buffer = buffer
             if let data = buffer.readData(length: buffer.readableBytes) {
                 handler(data)


### PR DESCRIPTION
## Summary
- switch HostStream data handler to new `setReadHandler` API
- forward inbound buffers as `Data`

## Testing
- `swift build` *(fails: Failed to clone repository https://github.com/swift-libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*
- `swift test` *(fails: Failed to clone repository https://github.com/swift-libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6892aee8264c832ba34a3cd87ec81e67