### PR TITLE
Pin swift-libp2p dependency to specific revision

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -159,7 +159,6 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-libp2p/swift-libp2p.git",
       "state" : {
-        "branch" : "main",
         "revision" : "dc07454017c573c9d2e45d3f3b14d32beda25ba0"
       }
     },

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     dependencies: [
         // Swift libp2p implementation providing the `Host` we wrap in
         // `LibP2PNode`.
-        .package(url: "https://github.com/swift-libp2p/swift-libp2p.git", branch: "main"),
+        .package(url: "https://github.com/swift-libp2p/swift-libp2p.git", revision: "dc07454017c573c9d2e45d3f3b14d32beda25ba0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "3.13.3"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.2")
     ],


### PR DESCRIPTION
## Summary
- Pin `swift-libp2p` to a specific commit for reproducible builds
- Update resolution file to reflect the pinned commit

## Testing
- `swift package update` *(fails: unable to access 'https://github.com/swift-libp2p/swift-libp2p.git': CONNECT tunnel failed)*
- `swift build` *(fails: unable to access 'https://github.com/swift-libp2p/swift-libp2p.git': CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6892aee94518832b875bc8be87edf5b7