### PR TITLE
Use readLoop for async stream reading

### DIFF
--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -149,10 +149,16 @@ private final class HostStream: LibP2PStream {
     }
 
     func setDataHandler(_ handler: @escaping (Data) -> Void) {
-        stream.setReadHandler { buffer in
-            var buffer = buffer
-            if let data = buffer.readData(length: buffer.readableBytes) {
-                handler(data)
+        Task.detached { [stream] in
+            do {
+                for try await buffer in stream.readLoop() {
+                    var buffer = buffer
+                    if let data = buffer.readData(length: buffer.readableBytes) {
+                        handler(data)
+                    }
+                }
+            } catch {
+                // Ignore errors from the read loop for now.
             }
         }
     }


### PR DESCRIPTION
## Summary
- replace deprecated setReadHandler with readLoop in HostStream

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/swift-libp2p/swift-libp2p.git: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6892b6a5615c832bb5d0b72d48a9ffe4