### PR TITLE
Refactor libp2p API usage

### DIFF
--- a/Sources/DHT.swift
+++ b/Sources/DHT.swift
@@ -74,52 +74,52 @@ public actor InMemoryDHT: DHT, Sendable {
 /// Peer identifiers are stored under their full geohash as well as all
 /// geohash prefixes to allow efficient prefix lookups.
 public actor LibP2PDHT: DHT, Sendable {
-    /// Transport manager driving libp2p networking.
-    private let transport: LibP2PCore.TransportManager
-    /// Swarm managing connections and protocols.
-    private let swarm: LibP2PCore.Swarm
-    /// Kademlia DHT service running on the swarm.
+    /// Transport driving libp2p networking.
+    private let transport: LibP2PCore.Transport
+    /// Host managing connections and protocols.
+    private let host: LibP2PCore.Host
+    /// Kademlia DHT service running on the host.
     private let kademlia: KademliaDHT
     /// Event loop group backing the transport manager.
     private let group: EventLoopGroup
     /// Logger for reporting DHT operations.
     private let logger = Logger(label: "DHT")
 
-    /// Creates a new libp2p backed DHT. A fresh transport manager and swarm are
+    /// Creates a new libp2p backed DHT. A fresh transport and host are
     /// constructed and started using the modern libp2p APIs.
     public init() throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
         self.group = group
 
-        let transport = LibP2PCore.TransportManager(group: group)
+        let transport = LibP2PCore.Transport(group: group)
         self.transport = transport
 
-        let swarm = try LibP2PCore.Swarm(transportManager: transport)
-        self.swarm = swarm
+        let host = try LibP2PCore.Host(transport: transport)
+        self.host = host
 
-        self.kademlia = KademliaDHT(swarm: swarm)
+        self.kademlia = KademliaDHT(host: host)
 
-        // Start the transport and swarm. The modern API uses synchronous
+        // Start the transport and host. The modern API uses synchronous
         // start methods which may throw.
         try transport.start()
-        try swarm.start()
+        try host.start()
     }
 
     deinit {
         // Stop the transport and shut down the underlying event loops.
-        try? transport.stop()
+        try? transport.close()
         try? group.syncShutdownGracefully()
     }
 
-    /// Connects this DHT's swarm to another peer in the network.
+    /// Connects this DHT's host to another peer in the network.
     public func bootstrap(to address: String) throws {
         let addr = try Multiaddr(address)
-        _ = try swarm.dial(addr)
+        _ = try host.dial(addr)
     }
 
     /// The multiaddresses this node is currently listening on.
     public var listenAddresses: [String] {
-        swarm.listenAddresses.map { $0.description }
+        host.listenAddresses.map { $0.description }
     }
 
     public func store(peerID: UUID, geohash: String) async throws {

--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -36,19 +36,19 @@ import LibP2PCore
 import NIO
 
 
-/// Concrete implementation backed by the real `swift-libp2p` `Swarm`.
+/// Concrete implementation backed by the real `swift-libp2p` `Host`.
 struct LibP2PHost: LibP2PHosting {
-    /// Concrete transport used by the underlying swarm.
+    /// Concrete transport used by the underlying host.
     private let transport: LibP2PCore.Transport
-    /// Libp2p swarm responsible for dialing and listening.
-    private let swarm: LibP2PCore.Swarm
+    /// Libp2p host responsible for dialing and listening.
+    private let host: LibP2PCore.Host
     /// Event loop group driving the networking stack.
     private let group: EventLoopGroup
 
     init() throws {
         // The latest libp2p API exposes builder utilities for constructing
-        // transports and the swarm/host. We configure a basic TCP transport and
-        // use it to build the swarm which manages connections.
+        // transports and the host. We configure a basic TCP transport and
+        // use it to build the host which manages connections.
         let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
         self.group = group
 
@@ -59,8 +59,8 @@ struct LibP2PHost: LibP2PHosting {
             .build()
             .wait()
 
-        // Create the swarm/host backed by the previously configured transport.
-        self.swarm = try LibP2P.SwarmBuilder(eventLoopGroup: group)
+        // Create the host backed by the previously configured transport.
+        self.host = try LibP2P.HostBuilder(eventLoopGroup: group)
             .withTransport(transport)
             .build()
             .wait()
@@ -68,9 +68,8 @@ struct LibP2PHost: LibP2PHosting {
 
     /// Start listening for connections.
     func start() throws {
-        // The new API returns an async task when starting; block until the
-        // underlying listeners are ready.
-        try swarm.start().wait()
+        // Start the host and block until listeners are ready.
+        try host.start()
     }
 
     /// Connect to a list of bootstrap peers so the node can discover the wider
@@ -78,16 +77,16 @@ struct LibP2PHost: LibP2PHosting {
     func bootstrap(peers: [String]) throws {
         for address in peers {
             let addr = try Multiaddr(address)
-            // Dial returns a future; wait for the connection attempt to
+            // Dial synchronously and wait for the connection attempt to
             // complete before moving onto the next address.
-            _ = try swarm.dial(addr).wait()
+            _ = try host.dial(addr)
         }
     }
 
     /// Shut down the host and release any associated resources.
     func stop() throws {
-        // Shut down the swarm/host and then the underlying event loop group.
-        try swarm.close().wait()
+        // Shut down the host and then the underlying event loop group.
+        try host.close()
         try group.syncShutdownGracefully()
     }
 
@@ -105,13 +104,13 @@ struct LibP2PHost: LibP2PHosting {
         }
         let maddr = multiaddrString(for: address, port: port)
         let addr = try Multiaddr(maddr)
-        let stream = try swarm.dial(addr).wait()
+        let stream = try host.dial(addr)
         return HostStream(peer: peer, stream: stream)
     }
 
     /// Register a handler for incoming streams initiated by remote peers.
     func setStreamHandler(_ handler: @escaping (LibP2PStream) -> Void) {
-        swarm.setStreamHandler { stream in
+        host.setStreamHandler { stream in
             // Derive a minimal `Peer` representation from the remote
             // connection. The remote address is extracted if available, but any
             // location information is left at defaults.
@@ -126,7 +125,7 @@ struct LibP2PHost: LibP2PHosting {
 
     /// The multiaddresses the underlying host is listening on.
     var listenAddresses: [String] {
-        swarm.listenAddresses.map { $0.description }
+        host.listenAddresses.map { $0.description }
     }
 }
 


### PR DESCRIPTION
## Summary
- replace deprecated Swarm usage with Host
- update start/dial/close calls to match new libp2p interfaces

## Testing
- `swift test` *(fails: unable to clone https://github.com/swift-libp2p/swift-libp2p.git CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6892b6a6c39c832ba8428410cb1cd4b0