### PR TITLE
Use transport close API and order shutdown

### DIFF
--- a/Sources/DHT.swift
+++ b/Sources/DHT.swift
@@ -106,8 +106,8 @@ public actor LibP2PDHT: DHT, Sendable {
     }
 
     deinit {
-        // Stop the transport and shut down the underlying event loops.
-        try? transport.stop()
+        // Close the transport and then shut down the underlying event loops.
+        try? transport.close().wait()
         try? group.syncShutdownGracefully()
     }
 


### PR DESCRIPTION
## Summary
- replace deprecated `transport.stop()` with `transport.close().wait()`
- keep event loop group shutdown after closing the transport to avoid leaks

## Testing
- `swift test` *(fails: unable to clone swift-libp2p due to CONNECT tunnel 403)*

------
https://chatgpt.com/codex/tasks/task_e_6892b6a844a8832bb474776c24513448