### PR TITLE
Wait for swarm dial

### DIFF
--- a/Sources/DHT.swift
+++ b/Sources/DHT.swift
@@ -114,7 +114,14 @@ public actor LibP2PDHT: DHT, Sendable {
     /// Connects this DHT's swarm to another peer in the network.
     public func bootstrap(to address: String) throws {
         let addr = try Multiaddr(address)
-        _ = try swarm.dial(addr)
+        do {
+            // The dial API now returns a future; wait for the connection
+            // attempt to complete so any errors are surfaced here.
+            _ = try swarm.dial(addr).wait()
+        } catch {
+            logger.error("Failed to dial bootstrap peer \(address): \(error)")
+            throw error
+        }
     }
 
     /// The multiaddresses this node is currently listening on.


### PR DESCRIPTION
## Summary
- wait for LibP2P swarm `dial` future when bootstrapping the DHT
- log dialing failures so callers get useful error details

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/swift-libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6892b6a8aa70832bbd8a41de9c55707a