### PR TITLE
Make LibP2P host start async

### DIFF
--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -67,10 +67,10 @@ struct LibP2PHost: LibP2PHosting {
     }
 
     /// Start listening for connections.
-    func start() throws {
-        // The new API returns an async task when starting; block until the
-        // underlying listeners are ready.
-        try swarm.start().wait()
+    func start() async throws {
+        // The new API returns an async task when starting; wait for completion
+        // before returning to ensure listeners are ready.
+        try await swarm.start()
     }
 
     /// Connect to a list of bootstrap peers so the node can discover the wider
@@ -172,7 +172,7 @@ protocol LibP2PStream {
 /// Abstraction over the underlying libp2p host so it can be mocked in tests.
 protocol LibP2PHosting {
     /// Start listening for connections and initialise any required services.
-    func start() throws
+    func start() async throws
     /// Connect to a set of bootstrap peers to join the network.
     func bootstrap(peers: [String]) throws
     /// Shut down the host and release any resources.
@@ -218,7 +218,7 @@ actor LibP2PNode {
     /// Start the underlying host and bootstrap to the configured peers. A
     /// stream handler is registered so incoming messages are automatically
     /// decoded and forwarded to the registered message handler.
-    func start() throws {
+    func start() async throws {
         guard host == nil else { return }
 
         let host = try hostBuilder()
@@ -228,7 +228,7 @@ actor LibP2PNode {
             Task { self.handleIncoming(stream: stream) }
         }
         do {
-            try host.start()
+            try await host.start()
             if !bootstrapPeers.isEmpty {
                 try host.bootstrap(peers: bootstrapPeers)
             }
@@ -350,7 +350,7 @@ actor P2PNode {
 
     /// Starts the networking stack by creating a libp2p host and performing
     /// bootstrap against known peers.
-    func start() throws {
+    func start() async throws {
         guard !isRunning else { return }
 
         let host = try hostBuilder()
@@ -360,7 +360,7 @@ actor P2PNode {
         }
 
         do {
-            try host.start()
+            try await host.start()
         } catch {
             logger.error("Failed to start host: \(error)")
             throw error

--- a/Tests/WeaveTests/EncryptionTests.swift
+++ b/Tests/WeaveTests/EncryptionTests.swift
@@ -61,7 +61,7 @@ final class EncryptionTests: XCTestCase {
 
             func connect(to host: StreamHost, as peer: Peer) { peers[peer.id] = (host, peer) }
 
-            func start() throws {}
+            func start() async throws {}
             func bootstrap(peers: [String]) throws {}
             func stop() throws {}
 
@@ -100,8 +100,8 @@ final class EncryptionTests: XCTestCase {
             exp.fulfill()
         }
 
-        await nodeA.start()
-        await nodeB.start()
+        try await nodeA.start()
+        try await nodeB.start()
 
         let stream = try await nodeA.openStream(to: peerB)! as! MockStream
         var captured: Data?

--- a/Tests/WeaveTests/LibP2PNodeWrapperTests.swift
+++ b/Tests/WeaveTests/LibP2PNodeWrapperTests.swift
@@ -8,7 +8,7 @@ final class LibP2PNodeWrapperTests: XCTestCase {
         var bootstrapped: [String] = []
         var handler: ((LibP2PStream) -> Void)?
 
-        func start() throws { started = true }
+        func start() async throws { started = true }
         func bootstrap(peers: [String]) throws { bootstrapped = peers }
         func stop() throws {}
         func openStream(to peer: Peer) throws -> LibP2PStream { NoopLibP2PStream(peer: peer) }
@@ -46,7 +46,7 @@ final class LibP2PNodeWrapperTests: XCTestCase {
 
         func connect(to host: StreamHost, as peer: Peer) { peers[peer.id] = (host, peer) }
 
-        func start() throws {}
+        func start() async throws {}
         func bootstrap(peers: [String]) throws {}
         func stop() throws {}
 

--- a/Tests/WeaveTests/P2PNodeTests.swift
+++ b/Tests/WeaveTests/P2PNodeTests.swift
@@ -8,7 +8,7 @@ final class P2PNodeTests: XCTestCase {
         var bootstrapped: [String] = []
         var stopCount = 0
 
-        func start() throws { startCount += 1 }
+        func start() async throws { startCount += 1 }
         func bootstrap(peers: [String]) throws { bootstrapped = peers }
         func stop() throws { stopCount += 1 }
         func openStream(to peer: Peer) throws -> LibP2PStream { NoopLibP2PStream(peer: peer) }
@@ -172,7 +172,7 @@ final class P2PNodeTests: XCTestCase {
 
         func connect(to host: StreamHost, as peer: Peer) { peers[peer.id] = (host, peer) }
 
-        func start() throws {}
+        func start() async throws {}
         func bootstrap(peers: [String]) throws {}
         func stop() throws {}
 
@@ -264,10 +264,10 @@ final class P2PNodeTests: XCTestCase {
         }
         await nodeB.setErrorHandler { _, _ in expError.fulfill() }
 
-        await nodeA.start()
-        await nodeB.start()
+        try await nodeA.start()
+        try await nodeB.start()
 
-        let streamAB = await nodeA.openStream(to: peerB)!
+        let streamAB = try await nodeA.openStream(to: peerB)!
         // Send unencrypted data which will fail decryption on nodeB
         streamAB.write(Data("garbage".utf8))
 


### PR DESCRIPTION
## Summary
- make libp2p host's start method asynchronous and await swarm startup
- propagate async throwing start through LibP2PHosting protocol and node wrappers
- update tests for async start behavior

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/swift-libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6892b6a9a4c8832bb73d480183d64f47