### PR TITLE
Use KademliaDHT product from swift-libp2p

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     dependencies: [
         // Swift libp2p implementation providing the `Host` we wrap in
         // `LibP2PNode`.
-        .package(url: "https://github.com/swift-libp2p/swift-libp2p.git", revision: "dc07454017c573c9d2e45d3f3b14d32beda25ba0"),
+        .package(url: "https://github.com/swift-libp2p/swift-libp2p.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "3.13.3"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.2")
     ],
@@ -24,7 +24,7 @@ let package = Package(
                 .product(name: "Crypto", package: "swift-crypto"),
                 // Once released, this product will expose the libp2p host implementation.
                 .product(name: "LibP2P", package: "swift-libp2p"),
-                .product(name: "LibP2PKademlia", package: "swift-libp2p"),
+                .product(name: "KademliaDHT", package: "swift-libp2p"),
                 .product(name: "Logging", package: "swift-log")
             ]),
         .testTarget(

--- a/Sources/DHT.swift
+++ b/Sources/DHT.swift
@@ -5,7 +5,7 @@ import Logging
 #if canImport(NIO)
 import NIO
 #endif
-import LibP2PKademlia
+import KademliaDHT
 
 /// Errors that can occur when writing values to the DHT.
 public enum DHTError: Error, Sendable {


### PR DESCRIPTION
## Summary
- point to swift-libp2p's KademliaDHT product and switch import
- track swift-libp2p on its main branch for the latest DHT modules

## Testing
- `swift build` *(fails: unable to access 'https://github.com/swift-libp2p/swift-libp2p.git/' - CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6892bb402748832b904e3761f3015bf7