### PR TITLE
Fix Kademlia dependency and imports

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
                 .product(name: "Crypto", package: "swift-crypto"),
                 // Once released, this product will expose the libp2p host implementation.
                 .product(name: "LibP2P", package: "swift-libp2p"),
-                .product(name: "KademliaDHT", package: "swift-libp2p"),
+                .product(name: "LibP2PKademlia", package: "swift-libp2p"),
                 .product(name: "Logging", package: "swift-log")
             ]),
         .testTarget(

--- a/Sources/DHT.swift
+++ b/Sources/DHT.swift
@@ -5,7 +5,7 @@ import Logging
 #if canImport(NIO)
 import NIO
 #endif
-import KademliaDHT
+import LibP2PKademlia
 
 /// Errors that can occur when writing values to the DHT.
 public enum DHTError: Error, Sendable {
@@ -76,7 +76,7 @@ public actor LibP2PDHT: DHT, Sendable {
     /// Host managing connections and protocols.
     private let host: LibP2PCore.Host
     /// Kademlia DHT service running on the host.
-    private let kademlia: KademliaDHT
+    private let kademlia: LibP2PKademlia
     /// Event loop group backing the transport manager.
 
     private let group: EventLoopGroup
@@ -98,7 +98,7 @@ public actor LibP2PDHT: DHT, Sendable {
         let host = try LibP2PCore.Host(transport: transport)
         self.host = host
 
-        self.kademlia = KademliaDHT(host: host)
+        self.kademlia = LibP2PKademlia(host: host)
 
         // Start the transport and host. The modern API uses synchronous
         // start methods which may throw.


### PR DESCRIPTION
## Summary
- point Kademlia dependency to `LibP2PKademlia`
- update DHT implementation to use the new module name

## Testing
- `swift build` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6892bebdca18832ba53fd7bd64a1a3e0