### PR TITLE
Add Kademlia dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
         // Swift libp2p implementation providing the `Host` we wrap in
         // `LibP2PNode`.
         .package(url: "https://github.com/swift-libp2p/swift-libp2p.git", branch: "main"),
+        .package(url: "https://github.com/swift-libp2p/swift-libp2p-kademlia.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "3.13.3"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.2")
     ],
@@ -24,7 +25,7 @@ let package = Package(
                 .product(name: "Crypto", package: "swift-crypto"),
                 // Once released, this product will expose the libp2p host implementation.
                 .product(name: "LibP2P", package: "swift-libp2p"),
-                .product(name: "LibP2PKademlia", package: "swift-libp2p"),
+                .product(name: "LibP2PKademlia", package: "swift-libp2p-kademlia"),
                 .product(name: "Logging", package: "swift-log")
             ]),
         .testTarget(

--- a/Sources/DHT.swift
+++ b/Sources/DHT.swift
@@ -5,7 +5,7 @@ import Logging
 #if canImport(NIO)
 import NIO
 #endif
-import LibP2PKademlia
+import Kademlia
 
 /// Errors that can occur when writing values to the DHT.
 public enum DHTError: Error, Sendable {


### PR DESCRIPTION
## Summary
- Add swift-libp2p-kademlia package
- Import Kademlia module in DHT

## Testing
- `swift build` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6892c38c3268832bb53b09cdcedd1393