### PR TITLE
fix: update kademlia dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,8 @@ let package = Package(
         // Swift libp2p implementation providing the `Host` we wrap in
         // `LibP2PNode`.
         .package(url: "https://github.com/swift-libp2p/swift-libp2p.git", branch: "main"),
-        .package(url: "https://github.com/swift-libp2p/swift-libp2p-kademlia.git", branch: "main"),
+        // Updated to the new Kademlia DHT package name.
+        .package(url: "https://github.com/swift-libp2p/swift-libp2p-kad-dht.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "3.13.3"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.2")
     ],
@@ -25,7 +26,8 @@ let package = Package(
                 .product(name: "Crypto", package: "swift-crypto"),
                 // Once released, this product will expose the libp2p host implementation.
                 .product(name: "LibP2P", package: "swift-libp2p"),
-                .product(name: "LibP2PKademlia", package: "swift-libp2p-kademlia"),
+                // Updated product name for the Kademlia DHT implementation.
+                .product(name: "LibP2PKadDHT", package: "swift-libp2p-kad-dht"),
                 .product(name: "Logging", package: "swift-log")
             ]),
         .testTarget(

--- a/Sources/DHT.swift
+++ b/Sources/DHT.swift
@@ -5,7 +5,7 @@ import Logging
 #if canImport(NIO)
 import NIO
 #endif
-import Kademlia
+import KadDHT
 
 /// Errors that can occur when writing values to the DHT.
 public enum DHTError: Error, Sendable {
@@ -76,7 +76,7 @@ public actor LibP2PDHT: DHT, Sendable {
     /// Host managing connections and protocols.
     private let host: LibP2PCore.Host
     /// Kademlia DHT service running on the host.
-    private let kademlia: LibP2PKademlia
+    private let kademlia: LibP2PKadDHT
     /// Event loop group backing the transport manager.
 
     private let group: EventLoopGroup
@@ -98,7 +98,7 @@ public actor LibP2PDHT: DHT, Sendable {
         let host = try LibP2PCore.Host(transport: transport)
         self.host = host
 
-        self.kademlia = LibP2PKademlia(host: host)
+        self.kademlia = LibP2PKadDHT(host: host)
 
         // Start the transport and host. The modern API uses synchronous
         // start methods which may throw.


### PR DESCRIPTION
## Summary
- use new swift-libp2p-kad-dht package
- wire code to LibP2PKadDHT type

## Testing
- `swift test` *(fails: unable to clone https://github.com/swift-libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6892c6c828d0832bba0fc4f8e725d2e7