### PR TITLE
Add property-based GeoHash round-trip tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,9 @@ let package = Package(
         // Updated to the new Kademlia DHT package name.
         .package(url: "https://github.com/swift-libp2p/swift-libp2p-kad-dht.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "3.13.3"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.2")
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.2"),
+        // Property-based testing framework used in the test suite.
+        .package(url: "https://github.com/typelift/SwiftCheck.git", from: "0.12.0")
     ],
     targets: [
         // Targets define modules or test suites.
@@ -32,6 +34,9 @@ let package = Package(
             ]),
         .testTarget(
             name: "WeaveTests",
-            dependencies: ["weave"])
+            dependencies: [
+                "weave",
+                .product(name: "SwiftCheck", package: "SwiftCheck")
+            ])
     ]
 )

--- a/Tests/WeaveTests/GeoHashPropertyTests.swift
+++ b/Tests/WeaveTests/GeoHashPropertyTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+import SwiftCheck
+@testable import weave
+
+final class GeoHashPropertyTests: XCTestCase {
+    func testRandomCoordinateRoundTrip() {
+        let coordinateGen = Gen<(Double, Double, Int)> { rng in
+            let lat = Double.random(in: -90.0...90.0, using: &rng)
+            let lon = Double.random(in: -180.0...180.0, using: &rng)
+            let precision = Int.random(in: 1...12, using: &rng)
+            return (lat, lon, precision)
+        }
+
+        property("encoding then decoding returns original coordinates") <- forAll(coordinateGen) { (lat, lon, precision) in
+            let hash = GeoHash.encode(latitude: lat, longitude: lon, precision: precision)
+            guard let (decodedLat, decodedLon) = try? GeoHash.decode(hash) else {
+                return false
+            }
+            let (latErr, lonErr) = errorForPrecision(precision)
+            return abs(decodedLat - lat) <= latErr / 2 && abs(decodedLon - lon) <= lonErr / 2
+        }
+    }
+}
+
+private func errorForPrecision(_ precision: Int) -> (Double, Double) {
+    var latBits = 0
+    var lonBits = 0
+    for i in 0..<(precision * 5) {
+        if i % 2 == 0 { lonBits += 1 } else { latBits += 1 }
+    }
+    let latErr = 180.0 / Double(1 << latBits)
+    let lonErr = 360.0 / Double(1 << lonBits)
+    return (latErr, lonErr)
+}


### PR DESCRIPTION
## Summary
- add SwiftCheck dependency for property-based testing
- verify GeoHash encode/decode with randomly generated coordinates

## Testing
- `swift test` *(fails: unable to access https://github.com/swift-libp2p/swift-libp2p.git)*

------
https://chatgpt.com/codex/tasks/task_e_68969a5d95e0832b88b099bab395020e