### PR TITLE
Switch to LibP2PKadDHT module

### DIFF
--- a/Sources/DHT.swift
+++ b/Sources/DHT.swift
@@ -5,7 +5,7 @@ import Logging
 #if canImport(NIO)
 import NIO
 #endif
-import KadDHT
+import LibP2PKadDHT
 
 /// Errors that can occur when writing values to the DHT.
 public enum DHTError: Error, Sendable {


### PR DESCRIPTION
## Summary
- replace obsolete `KadDHT` import with `LibP2PKadDHT`
- confirm Package.swift still uses `LibP2PKadDHT` product from `swift-libp2p-kad-dht`

## Testing
- `swift build` *(fails: Failed to clone repository https://github.com/swift-libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6897b52ead60832ba5e0069df7362f03