### PR TITLE
Adapt for host listeners API

### DIFF
--- a/Sources/DHT.swift
+++ b/Sources/DHT.swift
@@ -130,7 +130,7 @@ public actor LibP2PDHT: DHT, Sendable {
 
     /// The multiaddresses this node is currently listening on.
     public var listenAddresses: [String] {
-        host.listenAddresses.map { $0.description }
+        host.listeners.map { $0.address.description }
     }
 
     public func store(peerID: UUID, geohash: String) async throws {

--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -129,7 +129,7 @@ struct LibP2PHost: LibP2PHosting {
 
     /// The multiaddresses the underlying host is listening on.
     var listenAddresses: [String] {
-        host.listenAddresses.map { $0.description }
+        host.listeners.map { $0.address.description }
     }
 }
 

--- a/Tests/WeaveTests/LibP2PIntegrationTests.swift
+++ b/Tests/WeaveTests/LibP2PIntegrationTests.swift
@@ -6,8 +6,10 @@ final class LibP2PIntegrationTests: XCTestCase {
         let dhtA = try LibP2PDHT()
         let dhtB = try LibP2PDHT()
         // Connect the DHT instances so stored values propagate
-        for addr in await dhtA.listenAddresses { try await dhtB.bootstrap(to: addr) }
-        for addr in await dhtB.listenAddresses { try await dhtA.bootstrap(to: addr) }
+        let addrsA = await dhtA.listenAddresses
+        for addr in addrsA { try await dhtB.bootstrap(to: addr) }
+        let addrsB = await dhtB.listenAddresses
+        for addr in addrsB { try await dhtA.bootstrap(to: addr) }
 
         let peerID = UUID()
         try await dhtA.store(peerID: peerID, geohash: "u4pruydqqvj")


### PR DESCRIPTION
## Summary
- Adapt DHT listenAddresses to iterate over Host.listeners
- Replace Host.listenAddresses in LibP2PHost wrapper with Host.listeners
- Refresh integration test setup for updated listenAddresses usage

## Testing
- `swift build` *(failed: unable to access https://github.com/swift-libp2p/swift-libp2p.git, CONNECT tunnel failed, response 403)*
- `swift test` *(failed: unable to access https://github.com/swift-libp2p/swift-libp2p.git, CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6897b947c078832bb1981c56f7352eae