### PR TITLE
Update for async LibP2P

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,7 @@ let package = Package(
                 .product(name: "Crypto", package: "swift-crypto"),
                 // Once released, this product will expose the libp2p host implementation.
                 .product(name: "LibP2P", package: "swift-libp2p"),
+                .product(name: "LibP2PTransportTCP", package: "swift-libp2p"),
                 // Updated product name for the Kademlia DHT implementation.
                 .product(name: "LibP2PKadDHT", package: "swift-libp2p-kad-dht"),
                 .product(name: "Logging", package: "swift-log")

--- a/Sources/DHT.swift
+++ b/Sources/DHT.swift
@@ -6,6 +6,7 @@ import Logging
 import NIO
 #endif
 import LibP2PKadDHT
+import LibP2PTransportTCP
 
 /// Errors that can occur when writing values to the DHT.
 public enum DHTError: Error, Sendable {
@@ -72,11 +73,11 @@ public actor InMemoryDHT: DHT, Sendable {
 public actor LibP2PDHT: DHT, Sendable {
 
     /// Transport driving libp2p networking.
-    private let transport: LibP2PCore.Transport
+    private let transport: TCPTransport
     /// Host managing connections and protocols.
-    private let host: LibP2PCore.Host
+    private let host: LibP2P.Host
     /// Kademlia DHT service running on the host.
-    private let kademlia: LibP2PKadDHT
+    private let kademlia: KademliaDHT
     /// Event loop group backing the transport manager.
 
     private let group: EventLoopGroup
@@ -92,25 +93,24 @@ public actor LibP2PDHT: DHT, Sendable {
         self.group = group
 
 
-        let transport = LibP2PCore.Transport(group: group)
+        let transport = try TCPTransport(eventLoopGroup: group)
         self.transport = transport
 
-        let host = try LibP2PCore.Host(transport: transport)
+        let host = try LibP2PCore.HostBuilder(eventLoopGroup: group)
+            .withTransport(transport)
+            .build()
+            .wait()
         self.host = host
 
-        self.kademlia = LibP2PKadDHT(host: host)
+        self.kademlia = KademliaDHT(host: host)
 
-        // Start the transport and host. The modern API uses synchronous
-        // start methods which may throw.
-        try transport.start()
+        // Start the host which will implicitly start the transport.
         try host.start()
     }
 
     deinit {
 
-        // Close the transport and then shut down the underlying event loops.
-        try? transport.close().wait()
-
+        try? host.stop()
         try? group.syncShutdownGracefully()
     }
 

--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -32,6 +32,7 @@ func multiaddrString(for address: String, port: UInt16) -> String {
 #if canImport(LibP2P)
 import LibP2P
 import LibP2PCore
+import LibP2PTransportTCP
 
 import NIO
 
@@ -39,9 +40,9 @@ import NIO
 /// Concrete implementation backed by the real `swift-libp2p` `Host`.
 struct LibP2PHost: LibP2PHosting {
     /// Concrete transport used by the underlying host.
-    private let transport: LibP2PCore.Transport
+    private let transport: TCPTransport
     /// Libp2p host responsible for dialing and listening.
-    private let host: LibP2PCore.Host
+    private let host: LibP2P.Host
     /// Event loop group driving the networking stack.
     private let group: EventLoopGroup
 
@@ -61,7 +62,7 @@ struct LibP2PHost: LibP2PHosting {
 
 
         // Create the host backed by the previously configured transport.
-        self.host = try LibP2P.HostBuilder(eventLoopGroup: group)
+        self.host = try LibP2PCore.HostBuilder(eventLoopGroup: group)
             .withTransport(transport)
             .build()
             .wait()
@@ -90,7 +91,7 @@ struct LibP2PHost: LibP2PHosting {
     /// Shut down the host and release any associated resources.
     func stop() throws {
         // Shut down the host and then the underlying event loop group.
-        try host.close()
+        try host.stop()
         try group.syncShutdownGracefully()
     }
 
@@ -155,7 +156,7 @@ private final class HostStream: LibP2PStream {
     func setDataHandler(_ handler: @escaping (Data) -> Void) {
         Task.detached { [stream, logger] in
             do {
-                for try await buffer in stream.readLoop() {
+                while let buffer = try await stream.read() {
                     var buffer = buffer
                     if let data = buffer.readData(length: buffer.readableBytes) {
                         handler(data)


### PR DESCRIPTION
## Summary
- update libp2p integration for async API
- enable TCP transport product
- adjust DHT service for new host builder

## Testing
- `swift build` *(fails: Failed to clone repository https://github.com/swift-libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6897bb1d6868832b91d9ffea9c5e2055