### PR TITLE
Remove await from LibP2PHost start

### DIFF
--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -70,11 +70,11 @@ struct LibP2PHost: LibP2PHosting {
     }
 
     /// Start listening for connections.
-
     func start() async throws {
-        // The new API returns an async task when starting; wait for completion
-        // before returning to ensure listeners are ready.
-        try await host.start()
+        // Starting the host is a synchronous operation. We expose an
+        // `async` signature to conform to `LibP2PHosting` but no suspension is
+        // required here.
+        try host.start()
     }
 
     /// Connect to a list of bootstrap peers so the node can discover the wider


### PR DESCRIPTION
## Summary
- remove unnecessary await when starting LibP2P host

## Testing
- `swift build` *(fails: Failed to clone repository https://github.com/swift-libp2p/swift-libp2p.git: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6897bcaf0004832bb72201db5f48d92b