### PR TITLE
Clarify synchronous start for updated libp2p API

### DIFF
--- a/Sources/DHT.swift
+++ b/Sources/DHT.swift
@@ -104,7 +104,9 @@ public actor LibP2PDHT: DHT, Sendable {
 
         self.kademlia = KademliaDHT(host: host)
 
-        // Start the host which will implicitly start the transport.
+        // Start the host which will implicitly start the transport. The new
+        // libp2p API exposes synchronous start/stop operations so this call
+        // does not suspend.
         try host.start()
     }
 

--- a/Sources/P2PNode.swift
+++ b/Sources/P2PNode.swift
@@ -61,7 +61,9 @@ struct LibP2PHost: LibP2PHosting {
         self.transport = try TCPTransport(eventLoopGroup: group)
 
 
-        // Create the host backed by the previously configured transport.
+        // Create the host backed by the previously configured transport. The
+        // modern libp2p API uses a builder pattern that returns a future, so we
+        // block here to obtain the fully constructed host instance.
         self.host = try LibP2PCore.HostBuilder(eventLoopGroup: group)
             .withTransport(transport)
             .build()


### PR DESCRIPTION
## Summary
- Explain synchronous start/stop behavior in `LibP2PDHT`
- Document builder usage for constructing a libp2p host in `LibP2PHost`

## Testing
- `swift build` *(fails: Failed to clone repository https://github.com/swift-libp2p/swift-libp2p.git)*

------
https://chatgpt.com/codex/tasks/task_e_6897bdec7944832bbeb11b5327042a60