### PR TITLE
Add basic peer-to-peer networking support

### DIFF
--- a/weave/ContentView.swift
+++ b/weave/ContentView.swift
@@ -8,14 +8,45 @@
 import SwiftUI
 
 struct ContentView: View {
+    @StateObject private var manager = P2PManager()
+    @State private var host: String = ""
+    @State private var port: String = "9999"
+    @State private var outgoing: String = ""
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        VStack(spacing: 20) {
+            HStack {
+                TextField("Host", text: $host)
+                    .textFieldStyle(.roundedBorder)
+                TextField("Port", text: $port)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 80)
+                Button("Connect") {
+                    if let p = UInt16(port) {
+                        manager.connect(to: host, port: p)
+                    }
+                }
+            }
+
+            HStack {
+                TextField("Message", text: $outgoing)
+                    .textFieldStyle(.roundedBorder)
+                Button("Send") {
+                    manager.send(outgoing)
+                    outgoing = ""
+                }
+            }
+
+            List(manager.messages, id: \.self) { msg in
+                Text(msg)
+            }
         }
         .padding()
+        .onAppear {
+            if let p = UInt16(port) {
+                manager.startListening(on: p)
+            }
+        }
     }
 }
 

--- a/weave/P2PManager.swift
+++ b/weave/P2PManager.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Network
+import Combine
+
+/// Manages a basic peer-to-peer TCP connection with no central server.
+/// Each instance can listen for incoming peers and initiate connections to
+/// a known host. Received text messages are published via the `messages` array.
+class P2PManager: ObservableObject {
+    @Published var messages: [String] = []
+
+    private var listener: NWListener?
+    private var connection: NWConnection?
+    private let queue = DispatchQueue(label: "P2PManager")
+
+    /// Start listening for incoming peer connections on the provided port.
+    func startListening(on port: UInt16) {
+        do {
+            listener = try NWListener(using: .tcp, on: NWEndpoint.Port(rawValue: port)!)
+            listener?.newConnectionHandler = { [weak self] newConnection in
+                self?.setupConnection(newConnection)
+                newConnection.start(queue: self?.queue ?? .main)
+            }
+            listener?.start(queue: queue)
+        } catch {
+            print("Listener failed to start: \(error)")
+        }
+    }
+
+    /// Indicates whether the manager is currently listening for peers.
+    var isListening: Bool {
+        listener != nil
+    }
+
+    /// Connect to a remote peer at the given host and port.
+    func connect(to host: String, port: UInt16) {
+        connection = NWConnection(host: NWEndpoint.Host(host),
+                                  port: NWEndpoint.Port(rawValue: port)!,
+                                  using: .tcp)
+        connection?.stateUpdateHandler = { newState in
+            if case .failed(let error) = newState {
+                print("Connection failed: \(error)")
+            }
+        }
+        connection?.start(queue: queue)
+        setupReceive()
+    }
+
+    /// Send a string message to the connected peer.
+    func send(_ text: String) {
+        guard let connection else { return }
+        let data = text.data(using: .utf8) ?? Data()
+        connection.send(content: data, completion: .contentProcessed { _ in })
+    }
+
+    private func setupConnection(_ connection: NWConnection) {
+        self.connection = connection
+        setupReceive()
+    }
+
+    private func setupReceive() {
+        connection?.receive(minimumIncompleteLength: 1, maximumLength: 65535) { [weak self] data, _, isComplete, error in
+            if let data, let text = String(data: data, encoding: .utf8) {
+                DispatchQueue.main.async {
+                    self?.messages.append(text)
+                }
+            }
+
+            if error == nil && !isComplete {
+                self?.setupReceive()
+            }
+        }
+    }
+}

--- a/weaveTests/P2PManagerTests.swift
+++ b/weaveTests/P2PManagerTests.swift
@@ -1,0 +1,12 @@
+import Testing
+@testable import weave
+
+struct P2PManagerTests {
+    @Test func listenerStarts() async throws {
+        let manager = P2PManager()
+        manager.startListening(on: 9999)
+        // Wait briefly to allow listener to start
+        try await Task.sleep(nanoseconds: 100_000_000)
+        #expect(manager.isListening)
+    }
+}


### PR DESCRIPTION
## Summary
- enable peer-to-peer connections via new `P2PManager`
- provide simple UI to connect, send, and receive messages
- add unit test covering listener startup

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild test -scheme weave -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_689fe4b89998832b9197072d8caeb129