### PR TITLE
feat: expose public address for direct P2P

### DIFF
--- a/weave/ContentView.swift
+++ b/weave/ContentView.swift
@@ -6,6 +6,11 @@
 //
 
 import SwiftUI
+#if os(iOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
+#endif
 
 struct ContentView: View {
     @StateObject private var manager = P2PManager()
@@ -15,6 +20,20 @@ struct ContentView: View {
 
     var body: some View {
         VStack(spacing: 20) {
+            VStack {
+                Text("Your Address: \(manager.publicAddress.isEmpty ? "?" : manager.publicAddress):\(port)")
+#if os(iOS)
+                Button("Copy Address") {
+                    UIPasteboard.general.string = "\(manager.publicAddress):\(port)"
+                }
+#elseif os(macOS)
+                Button("Copy Address") {
+                    let pasteboard = NSPasteboard.general
+                    pasteboard.clearContents()
+                    pasteboard.setString("\(manager.publicAddress):\(port)", forType: .string)
+                }
+#endif
+            }
             HStack {
                 TextField("Host", text: $host)
                     .textFieldStyle(.roundedBorder)
@@ -46,6 +65,7 @@ struct ContentView: View {
             if let p = UInt16(port) {
                 manager.startListening(on: p)
             }
+            manager.fetchPublicIP()
         }
     }
 }

--- a/weave/P2PManager.swift
+++ b/weave/P2PManager.swift
@@ -7,6 +7,7 @@ import Combine
 /// a known host. Received text messages are published via the `messages` array.
 class P2PManager: ObservableObject {
     @Published var messages: [String] = []
+    @Published var publicAddress: String = ""
 
     private var listener: NWListener?
     private var connection: NWConnection?
@@ -29,6 +30,18 @@ class P2PManager: ObservableObject {
     /// Indicates whether the manager is currently listening for peers.
     var isListening: Bool {
         listener != nil
+    }
+
+    /// Retrieve the device's public IP address for sharing with peers.
+    func fetchPublicIP() {
+        guard let url = URL(string: "https://api.ipify.org?format=text") else { return }
+        URLSession.shared.dataTask(with: url) { [weak self] data, _, _ in
+            if let data, let ip = String(data: data, encoding: .utf8) {
+                DispatchQueue.main.async {
+                    self?.publicAddress = ip.trimmingCharacters(in: .whitespacesAndNewlines)
+                }
+            }
+        }.resume()
     }
 
     /// Connect to a remote peer at the given host and port.


### PR DESCRIPTION
## Summary
- show the device's public IP address and copyable connection string
- fetch public IP on launch to simplify remote peer setup

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project weave.xcodeproj -scheme weave -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d53e7050832bafdf94386f6f8b87