### PR TITLE
Add debug logging for connection flow

### DIFF
--- a/weave/ContentView.swift
+++ b/weave/ContentView.swift
@@ -41,6 +41,7 @@ struct ContentView: View {
                     .textFieldStyle(.roundedBorder)
                     .frame(width: 80)
                 Button("Connect") {
+                    print("Connect button tapped with host: \(host) port: \(port)")
                     if let p = UInt16(port) {
                         manager.connect(to: host, port: p)
                     }
@@ -51,6 +52,7 @@ struct ContentView: View {
                 TextField("Message", text: $outgoing)
                     .textFieldStyle(.roundedBorder)
                 Button("Send") {
+                    print("Send button tapped with message: \(outgoing)")
                     manager.send(outgoing)
                     outgoing = ""
                 }
@@ -62,6 +64,7 @@ struct ContentView: View {
         }
         .padding()
         .onAppear {
+            print("ContentView appeared")
             if let p = UInt16(port) {
                 manager.startListening(on: p)
             }

--- a/weave/P2PManager.swift
+++ b/weave/P2PManager.swift
@@ -13,17 +13,29 @@ class P2PManager: ObservableObject {
     private var connection: NWConnection?
     private let queue = DispatchQueue(label: "P2PManager")
 
+    private let debugLogsEnabled = true
+    private func log(_ message: String) {
+        guard debugLogsEnabled else { return }
+        print("[P2PManager] \(message)")
+    }
+
     /// Start listening for incoming peer connections on the provided port.
     func startListening(on port: UInt16) {
+        log("startListening on port \(port)")
         do {
             listener = try NWListener(using: .tcp, on: NWEndpoint.Port(rawValue: port)!)
+            listener?.stateUpdateHandler = { [weak self] state in
+                self?.log("Listener state changed: \(state)")
+            }
             listener?.newConnectionHandler = { [weak self] newConnection in
+                self?.log("Accepted new incoming connection")
                 self?.setupConnection(newConnection)
                 newConnection.start(queue: self?.queue ?? .main)
             }
             listener?.start(queue: queue)
+            log("Listening started")
         } catch {
-            print("Listener failed to start: \(error)")
+            log("Listener failed to start: \(error)")
         }
     }
 
@@ -34,11 +46,14 @@ class P2PManager: ObservableObject {
 
     /// Retrieve the device's public IP address for sharing with peers.
     func fetchPublicIP() {
+        log("Fetching public IP")
         guard let url = URL(string: "https://api.ipify.org?format=text") else { return }
         URLSession.shared.dataTask(with: url) { [weak self] data, _, _ in
             if let data, let ip = String(data: data, encoding: .utf8) {
                 DispatchQueue.main.async {
-                    self?.publicAddress = ip.trimmingCharacters(in: .whitespacesAndNewlines)
+                    let trimmed = ip.trimmingCharacters(in: .whitespacesAndNewlines)
+                    self?.publicAddress = trimmed
+                    self?.log("Public IP fetched: \(trimmed)")
                 }
             }
         }.resume()
@@ -46,38 +61,53 @@ class P2PManager: ObservableObject {
 
     /// Connect to a remote peer at the given host and port.
     func connect(to host: String, port: UInt16) {
+        log("Attempting to connect to \(host):\(port)")
         connection = NWConnection(host: NWEndpoint.Host(host),
                                   port: NWEndpoint.Port(rawValue: port)!,
                                   using: .tcp)
-        connection?.stateUpdateHandler = { newState in
+        connection?.stateUpdateHandler = { [weak self] newState in
+            self?.log("Connection state changed: \(newState)")
             if case .failed(let error) = newState {
-                print("Connection failed: \(error)")
+                self?.log("Connection failed: \(error)")
             }
         }
         connection?.start(queue: queue)
+        log("Connection started")
         setupReceive()
     }
 
     /// Send a string message to the connected peer.
     func send(_ text: String) {
-        guard let connection else { return }
+        log("Sending message: \(text)")
+        guard let connection else {
+            log("Cannot send, no active connection")
+            return
+        }
         let data = text.data(using: .utf8) ?? Data()
         connection.send(content: data, completion: .contentProcessed { _ in })
     }
 
     private func setupConnection(_ connection: NWConnection) {
+        log("Setting up connection")
         self.connection = connection
         setupReceive()
     }
 
     private func setupReceive() {
+        log("Preparing to receive data")
         connection?.receive(minimumIncompleteLength: 1, maximumLength: 65535) { [weak self] data, _, isComplete, error in
             if let data, let text = String(data: data, encoding: .utf8) {
+                self?.log("Received message: \(text)")
                 DispatchQueue.main.async {
                     self?.messages.append(text)
                 }
             }
-
+            if let error {
+                self?.log("Receive error: \(error)")
+            }
+            if isComplete {
+                self?.log("Receive completed")
+            }
             if error == nil && !isComplete {
                 self?.setupReceive()
             }


### PR DESCRIPTION
## Summary
- add central debug log utility in `P2PManager`
- log connection lifecycle events and data sends/receives
- print debug info in `ContentView` for button taps and view appearance

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e2846c28832ba990483bb16016b2