### PR TITLE
Add basic Kademlia-style DHT node

### DIFF
--- a/weave/Kademlia.swift
+++ b/weave/Kademlia.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// A very small and naive representation of a Kademlia-style
+/// distributed hash table (DHT) node. It is *not* a full
+/// implementation of the protocol but demonstrates the basic
+/// idea of storing and locating values by key using XOR distance.
+public final class KademliaNode {
+    public let id: UInt64
+    private var peers: [KademliaNode] = []
+    private var store: [UInt64: String] = [:]
+
+    public init(id: UInt64 = UInt64.random(in: 0..<UInt64.max)) {
+        self.id = id
+    }
+
+    /// Join the network by adding a bootstrap peer. In a full
+    /// implementation this would trigger bucket population and
+    /// key lookups but here it merely stores the reference.
+    public func join(bootstrap: KademliaNode) {
+        if !peers.contains(where: { $0 === bootstrap }) {
+            peers.append(bootstrap)
+        }
+    }
+
+    /// Store a value locally associated with the provided key.
+    /// In real Kademlia this would replicate to k closest nodes.
+    public func store(value: String, for key: UInt64) {
+        store[key] = value
+    }
+
+    /// Attempt to find a value for the given key. If not stored
+    /// locally, the query is forwarded to the known peer whose
+    /// ID is closest to the key according to XOR distance.
+    public func findValue(for key: UInt64) -> String? {
+        if let value = store[key] {
+            return value
+        }
+        guard let closest = peers.min(by: { ($0.id ^ key) < ($1.id ^ key) }) else {
+            return nil
+        }
+        return closest.findValue(for: key)
+    }
+}

--- a/weaveTests/KademliaTests.swift
+++ b/weaveTests/KademliaTests.swift
@@ -1,0 +1,18 @@
+import Testing
+@testable import weave
+
+struct KademliaTests {
+    /// Storing a value on a bootstrap node should allow a joined
+    /// node to retrieve it via the simplistic lookup mechanism.
+    @Test func storeAndLookup() async throws {
+        let bootstrap = KademliaNode(id: 1)
+        let node = KademliaNode(id: 2)
+        node.join(bootstrap: bootstrap)
+
+        let key: UInt64 = 42
+        bootstrap.store(value: "hello", for: key)
+
+        let result = node.findValue(for: key)
+        #expect(result == "hello")
+    }
+}


### PR DESCRIPTION
## Summary
- add a minimal KademliaNode for simple DHT-style storage and lookup
- add unit test verifying store and lookup across peers

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e4db5f84832b90c1afa7d0c4271c