### PR TITLE
Require iOS 13+ for Combine-based P2P manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,8 @@ import PackageDescription
 let package = Package(
     name: "weave",
     platforms: [
-        .macOS(.v13)
+        .macOS(.v13),
+        .iOS(.v13)
     ],
     products: [
         .library(name: "weave", targets: ["weave"])

--- a/weave/P2PManager.swift
+++ b/weave/P2PManager.swift
@@ -2,6 +2,7 @@ import Foundation
 import Network
 import Combine
 
+@available(iOS 13.0, macOS 10.15, *)
 class P2PManager: ObservableObject {
     @Published var messages: [String] = []
     @Published var publicAddress: String = ""


### PR DESCRIPTION
## Summary
- annotate `P2PManager` with iOS 13 / macOS 10.15 availability for `ObservableObject`
- declare iOS 13 as a supported platform in `Package.swift`

## Testing
- `swift test` *(fails: no such module 'Network')*

------
https://chatgpt.com/codex/tasks/task_e_68a7cf564c58832bb7a41d56101d22f8