### PR TITLE
Add app target with SwiftUI files and assets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,16 +4,27 @@ import PackageDescription
 let package = Package(
     name: "weave",
     platforms: [
-        .macOS(.v13)
+        .iOS(.v17), .macOS(.v13)
     ],
     products: [
-        .library(name: "weave", targets: ["weave"])
+        .library(name: "weave", targets: ["weave"]),
+        .executable(name: "weaveApp", targets: ["weaveApp"])
     ],
     targets: [
         .target(
             name: "weave",
             path: "weave",
-            exclude: ["ContentView.swift", "weaveApp.swift", "Assets.xcassets"]
+            exclude: ["ContentView.swift", "weaveApp.swift", "Assets.xcassets", "weave.entitlements"]
+        ),
+        .executableTarget(
+            name: "weaveApp",
+            dependencies: ["weave"],
+            path: "weave",
+            sources: ["ContentView.swift", "weaveApp.swift"],
+            resources: [
+                .process("Assets.xcassets"),
+                .copy("weave.entitlements")
+            ]
         ),
         .testTarget(name: "weaveTests", dependencies: ["weave"], path: "weaveTests")
     ]


### PR DESCRIPTION
## Summary
- specify iOS 17 and macOS 13 deployment targets
- add `weaveApp` executable target including SwiftUI views and assets

## Testing
- `swift test` *(fails: no such module 'Network')*

------
https://chatgpt.com/codex/tasks/task_e_68abcf7256b4832b8275c6557ace6e98