### PR TITLE
Specify library sources in Package manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,8 @@ let package = Package(
         .target(
             name: "weave",
             path: "weave",
-            exclude: ["ContentView.swift", "weaveApp.swift", "Assets.xcassets", "weave.entitlements"]
+            exclude: ["ContentView.swift", "weaveApp.swift", "Assets.xcassets", "weave.entitlements"],
+            sources: ["Kademlia.swift", "P2PManager.swift", "UPnPPortMapper.swift"]
         ),
         .executableTarget(
             name: "weaveApp",


### PR DESCRIPTION
## Summary
- Explicitly list core library Swift files in `Package.swift`

## Testing
- `swift build` *(fails: no such module 'Network')*
- `swift test` *(fails: no such module 'Network')*

------
https://chatgpt.com/codex/tasks/task_e_68abd4e92950832bb71a9d2180de4f07