### PR TITLE
Expose ContentView to executable target

### DIFF
--- a/weave/ContentView.swift
+++ b/weave/ContentView.swift
@@ -1,17 +1,18 @@
 import SwiftUI
-import weave
 #if os(iOS)
 import UIKit
 #elseif os(macOS)
 import AppKit
 #endif
 
-struct ContentView: View {
+public struct ContentView: View {
     @StateObject private var manager = P2PManager(port: 9999)
     @State private var bootstrapHost: String = ""
     @State private var peerID: String = ""
     @State private var outgoing: String = ""
     @State private var showError: Bool = false
+
+    public init() {}
 
     var body: some View {
         VStack(spacing: 20) {

--- a/weave/weaveApp.swift
+++ b/weave/weaveApp.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import weave
 
 @main
 struct weaveApp: App {


### PR DESCRIPTION
## Summary
- make `ContentView` public with a public initializer
- import the `weave` module in `weaveApp` so `ContentView` is available

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68ac71e95a88832bb249539a2010d4aa